### PR TITLE
Shallow clone and fetch to last tag to minimize history download

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,11 @@ jobs:
     name: Build
     runs-on: windows-2022
     steps:
-      - name: Checkout code
+      - name: Clone repo (shallow)
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
+
+      - name: Fetch code
+        run: git fetch --shallow-exclude=v4.0.0-rc.1
 
       # - name: Configure Visual Studio
       #   shell: cmd


### PR DESCRIPTION
The WiX build version includes a commit height since the last update to src\version.txt. Updates to version.txt happen after a tag for an official version so we can reduce the depth of the fetch significantly by only download git history after the last tag.