### PR TITLE
Fix harvesting project names with invalid chars

### DIFF
--- a/src/tools/heat/VSProjectHarvester.cs
+++ b/src/tools/heat/VSProjectHarvester.cs
@@ -367,7 +367,7 @@ namespace WixToolset.Harvesters
                 projectBaseDir = Path.GetDirectoryName(projectFile) + "\\";
             }
 
-            int harvestCount = this.HarvestProjectOutputGroupFiles(projectBaseDir, projectName, pog.Name, pog.FileSource, pogFiles, harvestParent);
+            int harvestCount = this.HarvestProjectOutputGroupFiles(projectBaseDir, sanitizedProjectName, pog.Name, pog.FileSource, pogFiles, harvestParent);
 
             if (this.GenerateType == GenerateType.Container)
             {

--- a/src/tools/test/WixToolsetTest.HeatTasks/MsbuildHeatFixture.cs
+++ b/src/tools/test/WixToolsetTest.HeatTasks/MsbuildHeatFixture.cs
@@ -200,62 +200,62 @@ namespace WixToolsetTest.Sdk
                 var warnings = result.Output.Where(line => line.Contains(": warning")).ToArray();
                 WixAssert.StringCollectionEmpty(warnings);
 
-                var generatedFilePath = Path.Combine(intermediateFolder, "Release", "_ToolsVersion4Cs.wxs");
+                var generatedFilePath = Path.Combine(intermediateFolder, "Release", "_Tools Version 4Cs.wxs");
                 Assert.True(File.Exists(generatedFilePath));
 
                 var generatedContents = File.ReadAllText(generatedFilePath);
                 var testXml = generatedContents.GetTestXml();
                 WixAssert.StringEqual(@"<Wix>" +
                     "<Fragment>" +
-                        "<DirectoryRef Id='ToolsVersion4Cs.Binaries'>" +
-                            "<Component Id='ToolsVersion4Cs.Binaries.ToolsVersion4Cs.dll' Guid='*'>" +
-                                "<File Id='ToolsVersion4Cs.Binaries.ToolsVersion4Cs.dll' Source='$(var.ToolsVersion4Cs.TargetDir)\\ToolsVersion4Cs.dll' />" +
+                        "<DirectoryRef Id='Tools_Version_4Cs.Binaries'>" +
+                            "<Component Id='Tools_Version_4Cs.Binaries.Tools_Version_4Cs.dll' Guid='*'>" +
+                                "<File Id='Tools_Version_4Cs.Binaries.Tools_Version_4Cs.dll' Source='$(var.Tools_Version_4Cs.TargetDir)\\Tools Version 4Cs.dll' />" +
                             "</Component>" +
                         "</DirectoryRef>" +
                     "</Fragment>" +
                     "<Fragment>" +
-                        "<ComponentGroup Id='ToolsVersion4Cs.Binaries'>" +
-                            "<ComponentRef Id='ToolsVersion4Cs.Binaries.ToolsVersion4Cs.dll' />" +
+                        "<ComponentGroup Id='Tools_Version_4Cs.Binaries'>" +
+                            "<ComponentRef Id='Tools_Version_4Cs.Binaries.Tools_Version_4Cs.dll' />" +
                         "</ComponentGroup>" +
                     "</Fragment>" +
                     "<Fragment>" +
-                        "<DirectoryRef Id='ToolsVersion4Cs.Symbols'>" +
-                            "<Component Id='ToolsVersion4Cs.Symbols.ToolsVersion4Cs.pdb' Guid='*'>" +
-                                "<File Id='ToolsVersion4Cs.Symbols.ToolsVersion4Cs.pdb' Source='$(var.ToolsVersion4Cs.TargetDir)\\ToolsVersion4Cs.pdb' />" +
+                        "<DirectoryRef Id='Tools_Version_4Cs.Symbols'>" +
+                            "<Component Id='Tools_Version_4Cs.Symbols.Tools_Version_4Cs.pdb' Guid='*'>" +
+                                "<File Id='Tools_Version_4Cs.Symbols.Tools_Version_4Cs.pdb' Source='$(var.Tools_Version_4Cs.TargetDir)\\Tools Version 4Cs.pdb' />" +
                             "</Component>" +
                         "</DirectoryRef>" +
                     "</Fragment>" +
                     "<Fragment>" +
-                        "<ComponentGroup Id='ToolsVersion4Cs.Symbols'>" +
-                            "<ComponentRef Id='ToolsVersion4Cs.Symbols.ToolsVersion4Cs.pdb' />" +
+                        "<ComponentGroup Id='Tools_Version_4Cs.Symbols'>" +
+                            "<ComponentRef Id='Tools_Version_4Cs.Symbols.Tools_Version_4Cs.pdb' />" +
                         "</ComponentGroup>" +
                     "</Fragment>" +
                     "<Fragment>" +
-                        "<DirectoryRef Id='ToolsVersion4Cs.Sources'>" +
-                            "<Component Id='ToolsVersion4Cs.Sources.ToolsVersion4Cs.csproj' Guid='*'>" +
-                                "<File Id='ToolsVersion4Cs.Sources.ToolsVersion4Cs.csproj' Source='$(var.ToolsVersion4Cs.ProjectDir)\\ToolsVersion4Cs.csproj' />" +
+                        "<DirectoryRef Id='Tools_Version_4Cs.Sources'>" +
+                            "<Component Id='Tools_Version_4Cs.Sources.Tools_Version_4Cs.csproj' Guid='*'>" +
+                                "<File Id='Tools_Version_4Cs.Sources.Tools_Version_4Cs.csproj' Source='$(var.Tools_Version_4Cs.ProjectDir)\\Tools Version 4Cs.csproj' />" +
                             "</Component>" +
-                            "<Directory Id='ToolsVersion4Cs.Sources.Properties' Name='Properties'>" +
-                                "<Component Id='ToolsVersion4Cs.Sources.AssemblyInfo.cs' Guid='*'>" +
-                                    "<File Id='ToolsVersion4Cs.Sources.AssemblyInfo.cs' Source='$(var.ToolsVersion4Cs.ProjectDir)\\Properties\\AssemblyInfo.cs' />" +
+                            "<Directory Id='Tools_Version_4Cs.Sources.Properties' Name='Properties'>" +
+                                "<Component Id='Tools_Version_4Cs.Sources.AssemblyInfo.cs' Guid='*'>" +
+                                    "<File Id='Tools_Version_4Cs.Sources.AssemblyInfo.cs' Source='$(var.Tools_Version_4Cs.ProjectDir)\\Properties\\AssemblyInfo.cs' />" +
                                 "</Component>" +
                             "</Directory>" +
                         "</DirectoryRef>" +
                     "</Fragment>" +
                     "<Fragment>" +
-                        "<ComponentGroup Id='ToolsVersion4Cs.Sources'>" +
-                            "<ComponentRef Id='ToolsVersion4Cs.Sources.ToolsVersion4Cs.csproj' />" +
-                            "<ComponentRef Id='ToolsVersion4Cs.Sources.AssemblyInfo.cs' />" +
+                        "<ComponentGroup Id='Tools_Version_4Cs.Sources'>" +
+                            "<ComponentRef Id='Tools_Version_4Cs.Sources.Tools_Version_4Cs.csproj' />" +
+                            "<ComponentRef Id='Tools_Version_4Cs.Sources.AssemblyInfo.cs' />" +
                         "</ComponentGroup>" +
                     "</Fragment>" +
                     "<Fragment>" +
-                        "<ComponentGroup Id='ToolsVersion4Cs.Content' />" +
+                        "<ComponentGroup Id='Tools_Version_4Cs.Content' />" +
                     "</Fragment>" +
                     "<Fragment>" +
-                        "<ComponentGroup Id='ToolsVersion4Cs.Satellites' />" +
+                        "<ComponentGroup Id='Tools_Version_4Cs.Satellites' />" +
                     "</Fragment>" +
                     "<Fragment>" +
-                        "<ComponentGroup Id='ToolsVersion4Cs.Documents' />" +
+                        "<ComponentGroup Id='Tools_Version_4Cs.Documents' />" +
                     "</Fragment>" +
                     "</Wix>", testXml);
 
@@ -266,7 +266,7 @@ namespace WixToolsetTest.Sdk
                 var section = intermediate.Sections.Single();
 
                 var fileSymbol = section.Symbols.OfType<FileSymbol>().Single();
-                WixAssert.StringEqual(Path.Combine(fs.BaseFolder, "ToolsVersion4Cs", "bin", "Release\\\\ToolsVersion4Cs.dll"), fileSymbol[FileSymbolFields.Source].AsPath()?.Path);
+                WixAssert.StringEqual(Path.Combine(fs.BaseFolder, "Tools Version 4Cs", "bin", "Release\\\\Tools Version 4Cs.dll"), fileSymbol[FileSymbolFields.Source].AsPath()?.Path);
             }
         }
 

--- a/src/tools/test/WixToolsetTest.HeatTasks/TestData/HeatProject/HeatProjectPreSdkStyle/HeatProjectPreSdkStyle.wixproj
+++ b/src/tools/test/WixToolsetTest.HeatTasks/TestData/HeatProject/HeatProjectPreSdkStyle/HeatProjectPreSdkStyle.wixproj
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ToolsVersion4Cs\ToolsVersion4Cs.csproj" />
+    <ProjectReference Include="..\Tools Version 4Cs\Tools Version 4Cs.csproj" />
   </ItemGroup>
 
   <Import Project="$(HeatTargetsPath)" />

--- a/src/tools/test/WixToolsetTest.HeatTasks/TestData/HeatProject/HeatProjectPreSdkStyle/Package.wxs
+++ b/src/tools/test/WixToolsetTest.HeatTasks/TestData/HeatProject/HeatProjectPreSdkStyle/Package.wxs
@@ -5,13 +5,13 @@
     <MediaTemplate />
 
     <Feature Id="ProductFeature" Title="HeatProjectFeature">
-      <ComponentGroupRef Id="ToolsVersion4Cs.Binaries" />
+      <ComponentGroupRef Id="Tools_Version_4Cs.Binaries" />
     </Feature>
   </Package>
 
   <Fragment>
     <StandardDirectory Id="ProgramFilesFolder">
-      <Directory Id="ToolsVersion4Cs.Binaries" Name="MsiPackage" />
+      <Directory Id="Tools_Version_4Cs.Binaries" Name="MsiPackage" />
     </StandardDirectory>
   </Fragment>
 </Wix>

--- a/src/tools/test/WixToolsetTest.HeatTasks/TestData/HeatProject/Tools Version 4Cs/Properties/AssemblyInfo.cs
+++ b/src/tools/test/WixToolsetTest.HeatTasks/TestData/HeatProject/Tools Version 4Cs/Properties/AssemblyInfo.cs
@@ -4,8 +4,8 @@ using System;
 using System.Reflection;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("ToolsVersion4Cs")]
-[assembly: AssemblyDescription("ToolsVersion4Cs")]
+[assembly: AssemblyTitle("Tools Version 4Cs")]
+[assembly: AssemblyDescription("Tools Version 4Cs")]
 [assembly: AssemblyProduct("WiX Toolset")]
 [assembly: AssemblyCompany("WiX Toolset Team")]
 [assembly: AssemblyCopyright("Copyright (c) .NET Foundation and contributors. All rights reserved.")]

--- a/src/tools/test/WixToolsetTest.HeatTasks/TestData/HeatProject/Tools Version 4Cs/Tools Version 4Cs.csproj
+++ b/src/tools/test/WixToolsetTest.HeatTasks/TestData/HeatProject/Tools Version 4Cs/Tools Version 4Cs.csproj
@@ -5,7 +5,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <ProjectGuid>{8B19578A-816A-48A1-A6C4-58067334EB79}</ProjectGuid>
-    <AssemblyName>ToolsVersion4Cs</AssemblyName>
+    <AssemblyName>Tools Version 4Cs</AssemblyName>
     <OutputType>Library</OutputType>
     <RootNamespace>ToolsVersion4Cs</RootNamespace>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/7408

Project names with invalid characters, namely spaces, were not being harvested properly. The sanitized name is required for the `Source="$(var.PROJECT_NAME` output.