### PR TITLE
Show correct error message when upgrade is blocked

### DIFF
--- a/src/wix/WixToolset.Core/Compiler.cs
+++ b/src/wix/WixToolset.Core/Compiler.cs
@@ -6635,7 +6635,7 @@ namespace WixToolset.Core
                     this.Core.AddSymbol(new LaunchConditionSymbol(sourceLineNumbers)
                     {
                         Condition = WixUpgradeConstants.UpgradePreventedCondition,
-                        Description = downgradeErrorMessage
+                        Description = disallowUpgradeErrorMessage
                     });
                 }
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Upgrade/MajorUpgradeDowngradeMessage.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Upgrade/MajorUpgradeDowngradeMessage.wxs
@@ -1,0 +1,15 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MajorUpgradeDowngradeMessage" Language="1033" Version="2.0.0" Manufacturer="Example Corporation" UpgradeCode="7ab24276-c628-43db-9e65-a184d052909b" Scope="perMachine">
+
+        <MajorUpgrade Disallow="yes" DisallowUpgradeErrorMessage="No upgrades allowed!" DowngradeErrorMessage="No downgrades allowed!" />
+
+        <Feature Id="ProductFeature" Title="MsiPackageTitle">
+        </Feature>
+    </Package>
+
+    <Fragment>
+        <StandardDirectory Id="ProgramFiles6432Folder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
@@ -11,9 +11,8 @@ namespace WixToolsetTest.CoreIntegration
 
     public class UpgradeFixture
     {
-
         [Fact]
-        public void PopulatesInstallExecuteSequenceTable()
+        public void FailsOnInvalidVersion()
         {
             var folder = TestData.Get(@"TestData");
 
@@ -43,6 +42,28 @@ namespace WixToolsetTest.CoreIntegration
                 }, errorMessages);
                 Assert.Equal(242, result.ExitCode);
             }
+        }
+
+        [Fact]
+        public void MajorUpgradeDowngradeMessagePopulatesRowsAsExpected()
+        {
+            var folder = TestData.Get("TestData", "Upgrade");
+            var build = new Builder(folder, null, new[] { folder });
+
+            var results = build.BuildAndQuery(Build, "Upgrade", "LaunchCondition");
+            WixAssert.CompareLineByLine(new[]
+            {
+                "LaunchCondition:NOT WIX_DOWNGRADE_DETECTED\tNo downgrades allowed!",
+                "LaunchCondition:NOT WIX_UPGRADE_DETECTED\tNo upgrades allowed!",
+                "Upgrade:{7AB24276-C628-43DB-9E65-A184D052909B}\t\t2.0.0\t1033\t1\t\tWIX_UPGRADE_DETECTED",
+                "Upgrade:{7AB24276-C628-43DB-9E65-A184D052909B}\t2.0.0\t\t1033\t2\t\tWIX_DOWNGRADE_DETECTED",
+            }, results);
+        }
+
+        private static void Build(string[] args)
+        {
+            var result = WixRunner.Execute(args);
+            result.AssertSuccess();
         }
     }
 }


### PR DESCRIPTION
Fixes [#7416](https://github.com/wixtoolset/issues/issues/7416#issue-1672794551)