### PR TITLE
Allow "." as valid Directory SourceName

### DIFF
--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
@@ -507,7 +507,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 shortName = this.CreateShortName(name, false, "Directory", symbol.ParentDirectoryRef);
             }
 
-            if (String.IsNullOrEmpty(sourceShortname) && !String.IsNullOrEmpty(symbol.SourceName) && !this.BackendHelper.IsValidShortFilename(symbol.SourceName, false))
+            if (String.IsNullOrEmpty(sourceShortname) && !String.IsNullOrEmpty(symbol.SourceName) && symbol.SourceName != "." && !this.BackendHelper.IsValidShortFilename(symbol.SourceName, false))
             {
                 sourceShortname = this.CreateShortName(symbol.SourceName, false, "Directory", symbol.ParentDirectoryRef);
             }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/Package.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/Package.wxs
@@ -11,7 +11,7 @@
 
   <Fragment>
     <StandardDirectory Id="ProgramFilesFolder">
-      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" SourceName="." />
     </StandardDirectory>
   </Fragment>
 </Wix>


### PR DESCRIPTION
Fixes wixtoolset/issues#7384