### PR TITLE
Obsolete removed PackageState.Cached value

### DIFF
--- a/src/api/burn/WixToolset.Mba.Core/IBootstrapperEngine.cs
+++ b/src/api/burn/WixToolset.Mba.Core/IBootstrapperEngine.cs
@@ -408,11 +408,6 @@ namespace WixToolset.Mba.Core
         Absent,
 
         /// <summary>
-        /// The package is not installed but is in the package cache.
-        /// </summary>
-        Cached,
-
-        /// <summary>
         /// The package is installed.
         /// </summary>
         Present,
@@ -421,6 +416,12 @@ namespace WixToolset.Mba.Core
         /// The package is on the machine but not active, so only uninstall operations are allowed.
         /// </summary>
         Superseded,
+
+        /// <summary>
+        /// This value is no longer used. See the DetectPackageCompleteEventArgs.Cached value instead.
+        /// </summary>
+        [Obsolete("Use DetectPackageCompleteEventArgs.Cached instead.")]
+        Cached = Present,
     }
 
     /// <summary>

--- a/src/test/burn/TestBA/TestBA.cs
+++ b/src/test/burn/TestBA/TestBA.cs
@@ -299,7 +299,7 @@ namespace WixToolset.Test.BA
                 args.CacheType = cacheType;
             }
 
-            this.Log("OnPlanPackageBegin() - id: {0}, defaultState: {1}, requestedState: {2}, defaultCache: {3}, requestedCache: {4}", args.PackageId, args.RecommendedState, args.State, args.RecommendedCacheType, args.CacheType);
+            this.Log("OnPlanPackageBegin() - id: {0}, currentState: {1}, defaultState: {2}, requestedState: {3}, defaultCache: {4}, requestedCache: {5}", args.PackageId, args.CurrentState, args.RecommendedState, args.State, args.RecommendedCacheType, args.CacheType);
         }
 
         protected override void OnPlanPatchTarget(PlanPatchTargetEventArgs args)


### PR DESCRIPTION
A package's cached status is no longer set via the PackageState. The value was removed in the native code, but the managed code was missed throwing off the enum mapping.

Fixes wixtoolset/issues#7399