### PR TITLE
ProjectReferences to wixlibs should participate in DefineConstants creation

### DIFF
--- a/src/test/wix/TestData/WixprojPackageVcxprojWindowsApp/Package.wxs
+++ b/src/test/wix/TestData/WixprojPackageVcxprojWindowsApp/Package.wxs
@@ -1,3 +1,7 @@
+<?ifndef WixprojLibraryVcxprojDll.ProjectDir ?>
+<?error This error should not be hit when wixlib ProjectReferences correctly create their DefineConstants. ?>
+<?endif?>
+
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
      xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
   <Package Name='!(loc.PackageName)' Manufacturer='WiX Toolset' Version='0.0.1' UpgradeCode='41a2c17e-1976-465b-bcde-eae03516ca68'>

--- a/src/wix/WixToolset.Sdk/tools/wix.targets
+++ b/src/wix/WixToolset.Sdk/tools/wix.targets
@@ -331,7 +331,6 @@
 
     <ItemGroup>
       <WixLibrary Include="@(_WixResolvedProjectReference)" Condition=" '%(Extension)' == '.wixlib' " />
-      <_WixResolvedProjectReference Remove="@(WixLibrary)" />
     </ItemGroup>
 
     <!-- Convert resolved project references into compiler defines and named and unamed bind paths -->
@@ -366,11 +365,11 @@
 
     [IN]
     @(WixLibrary) - the list of .wixlib files.
-    @(_WixResolvedProjectReference) - resolved project references.
     $(WixLibrarySearchPaths) - optional search paths used to find .wixlibs.
 
     [OUT]
-    @(_ResolvedWixLibraryPaths) - Item group with full paths to libraries
+    @(_ResolvedWixLibraryPaths) - Item group with full paths to libraries that were found.
+    @(_UnresolvedWixLibraryPaths) - Item group with full paths to libraries that were not found.
     ================================================================================================
     -->
   <PropertyGroup>


### PR DESCRIPTION
Also, fix documentation in ResolveWixLibraryReferences target.

Fixes wixtoolset/issues#7512