### PR TITLE
Automatically add logging flag for any burn ExePackage, BundlePackage, and related bundles

### DIFF
--- a/src/burn/engine/bundlepackageengine.cpp
+++ b/src/burn/engine/bundlepackageengine.cpp
@@ -1000,6 +1000,9 @@ static HRESULT ExecuteBundle(
         ExitOnFailure(hr, "Failed to allocate obfuscated bundle command.");
     }
 
+    // Append logging to command line if it doesn't contain '-log'
+    CoreAppendLogToCommandLine(&sczBaseCommand, &sczCommandObfuscated, fRollback, pVariables, pPackage);
+
     // Log obfuscated command, which won't include raw hidden variable values or protocol specific arguments to avoid exposing secrets.
     LogId(REPORT_STANDARD, MSG_APPLYING_PACKAGE, LoggingRollbackOrExecute(fRollback), pPackage->sczId, LoggingActionStateToString(action), sczExecutablePath, sczCommandObfuscated ? sczCommandObfuscated : sczBaseCommand);
 

--- a/src/burn/engine/core.h
+++ b/src/burn/engine/core.h
@@ -306,6 +306,13 @@ HRESULT CoreAppendFileHandleSelfToCommandLine(
     __deref_inout_z LPWSTR* psczCommandLine,
     __deref_inout_z_opt LPWSTR* psczObfuscatedCommandLine
     );
+HRESULT CoreAppendLogToCommandLine(
+    __deref_inout_z LPWSTR* psczCommandLine,
+    __deref_inout_z_opt LPWSTR* psczObfuscatedCommandLine,
+    __in BOOL fRollback,
+    __in BURN_VARIABLES* pVariables,
+    __in BURN_PACKAGE *pPackage
+    );
 HRESULT CoreAppendSplashScreenWindowToCommandLine(
     __in_opt HWND hwndSplashScreen,
     __deref_inout_z LPWSTR* psczCommandLine

--- a/src/burn/engine/exeengine.cpp
+++ b/src/burn/engine/exeengine.cpp
@@ -624,6 +624,12 @@ extern "C" HRESULT ExeEngineExecutePackage(
         ExitOnFailure(hr, "Failed to append %ls", BURN_COMMANDLINE_SWITCH_FILEHANDLE_SELF);
     }
 
+    // For bundles, append logging to command line if it doesn't contain '-log'
+    if (pPackage->Exe.fBundle || BURN_EXE_PROTOCOL_TYPE_BURN == pPackage->Exe.protocol)
+    {
+        CoreAppendLogToCommandLine(&sczBaseCommand, &sczCommandObfuscated, fRollback, pVariables, pPackage);
+    }
+
     // build user args
     if (sczUnformattedUserArgs && *sczUnformattedUserArgs)
     {

--- a/src/burn/engine/logging.cpp
+++ b/src/burn/engine/logging.cpp
@@ -325,6 +325,19 @@ extern "C" HRESULT LoggingSetPackageVariable(
         ExitFunction();
     }
 
+    // For burn packages we'll add logging even it it wasn't explictly specified
+    if (BURN_PACKAGE_TYPE_BUNDLE == pPackage->type || (BURN_PACKAGE_TYPE_EXE == pPackage->type && BURN_EXE_PROTOCOL_TYPE_BURN == pPackage->Exe.protocol))
+    {
+        if (!fRollback && (!pPackage->sczLogPathVariable || !*pPackage->sczLogPathVariable))
+        {
+            StrAllocFormatted(&pPackage->sczLogPathVariable, L"WixBundleLog_%ls", pPackage->sczId);
+        }
+        else if (fRollback && (!pPackage->sczRollbackLogPathVariable || !*pPackage->sczRollbackLogPathVariable))
+        {
+            StrAllocFormatted(&pPackage->sczRollbackLogPathVariable, L"WixBundleRollbackLog_%ls", pPackage->sczId);
+        }
+    }
+
     if ((!fRollback && pPackage->sczLogPathVariable && *pPackage->sczLogPathVariable) ||
         (fRollback && pPackage->sczRollbackLogPathVariable && *pPackage->sczRollbackLogPathVariable))
     {

--- a/src/burn/engine/pseudobundle.cpp
+++ b/src/burn/engine/pseudobundle.cpp
@@ -27,7 +27,7 @@ extern "C" HRESULT PseudoBundleInitializeRelated(
     ExitOnNull(pPackage->payloads.rgItems, hr, E_OUTOFMEMORY, "Failed to allocate space for burn payload group inside of related bundle struct");
     pPackage->payloads.cItems = 1;
 
-    pPayload = (BURN_PAYLOAD*)MemAlloc(sizeof(BURN_PAYLOAD), TRUE); 
+    pPayload = (BURN_PAYLOAD*)MemAlloc(sizeof(BURN_PAYLOAD), TRUE);
     ExitOnNull(pPayload, hr, E_OUTOFMEMORY, "Failed to allocate space for burn payload inside of related bundle struct");
     pPackage->payloads.rgItems[0].pPayload = pPayload;
     pPayload->packaging = BURN_PAYLOAD_PACKAGING_EXTERNAL;
@@ -58,6 +58,10 @@ extern "C" HRESULT PseudoBundleInitializeRelated(
 
     hr = StrAllocString(&pPackage->sczCacheId, wzId, 0);
     ExitOnFailure(hr, "Failed to copy cache id for pseudo bundle.");
+
+    // Log variables - best effort
+    StrAllocFormatted(&pPackage->sczLogPathVariable, L"WixBundleLog_%ls", pPackage->sczId);
+    StrAllocFormatted(&pPackage->sczRollbackLogPathVariable, L"WixBundleRollbackLog_%ls", pPackage->sczId);
 
     if (pDependencyProvider)
     {
@@ -121,6 +125,10 @@ extern "C" HRESULT PseudoBundleInitializePassthrough(
 
     hr = StrAllocString(&pPassthroughPackage->sczCacheId, pPackage->sczCacheId, 0);
     ExitOnFailure(hr, "Failed to copy cache id for passthrough pseudo bundle.");
+
+    // Log variables - best effort
+    StrAllocFormatted(&pPackage->sczLogPathVariable, L"WixBundleLog_%ls", pPackage->sczId);
+    StrAllocFormatted(&pPackage->sczRollbackLogPathVariable, L"WixBundleRollbackLog_%ls", pPackage->sczId);
 
     hr = CoreCreatePassthroughBundleCommandLine(&sczArguments, pInternalCommand, pCommand);
     ExitOnFailure(hr, "Failed to create command-line arguments.");
@@ -206,6 +214,10 @@ extern "C" HRESULT PseudoBundleInitializeUpdateBundle(
 
     hr = StrAllocString(&pPackage->sczCacheId, wzCacheId, 0);
     ExitOnFailure(hr, "Failed to copy cache id for update bundle.");
+
+    // Log variables - best effort
+    StrAllocFormatted(&pPackage->sczLogPathVariable, L"WixBundleLog_%ls", pPackage->sczId);
+    StrAllocFormatted(&pPackage->sczRollbackLogPathVariable, L"WixBundleRollbackLog_%ls", pPackage->sczId);
 
     hr = StrAllocString(&pPackage->Exe.sczInstallArguments, wzInstallArguments, 0);
     ExitOnFailure(hr, "Failed to copy install arguments for update bundle package");


### PR DESCRIPTION
Fixes wixtoolset/issues#5220: Automatically add logging flag for any burn ExePackage, BundlePackage, and related bundles