### PR TITLE
Partial fix for the weirdly broken...

### DIFF
--- a/src/api/wix/WixToolset.Extensibility/Data/IWindowsInstallerDecompileContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/IWindowsInstallerDecompileContext.cs
@@ -93,7 +93,8 @@ namespace WixToolset.Extensibility.Data
         bool SuppressUI { get; set; }
 
         /// <summary>
-        /// Gets or sets whether the decompiler should use module logic on a product output.
+        /// Gets or sets whether the decompiler should keep modularization
+        /// GUIDs (true) or remove them (default/false).
         /// </summary>
         bool TreatProductAsModule { get; set; }
     }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Decompile/Decompiler.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Decompile/Decompiler.cs
@@ -1188,11 +1188,11 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
                     var fileName = xFile?.Attribute("Name")?.Value;
 
                     // set the source (done here because it requires information from the Directory table)
-                    if (OutputType.Module == this.OutputType)
+                    if (OutputType.Module == this.OutputType && !this.TreatProductAsModule)
                     {
                         xFile.SetAttributeValue("Source", String.Concat(this.BaseSourcePath, Path.DirectorySeparatorChar, "File", Path.DirectorySeparatorChar, fileId, '.', this.ModularizationGuid.Substring(1, 36).Replace('-', '_')));
                     }
-                    else if (fileCompressed == "yes" || (fileCompressed != "no" && this.Compressed) || (OutputType.Package == this.OutputType && this.TreatProductAsModule))
+                    else if (fileCompressed == "yes" || (fileCompressed != "no" && this.Compressed) || OutputType.Module == this.OutputType)
                     {
                         xFile.SetAttributeValue("Source", String.Concat(this.BaseSourcePath, Path.DirectorySeparatorChar, "File", Path.DirectorySeparatorChar, fileId));
                     }
@@ -1898,7 +1898,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
         private void FinalizeSequenceTables(TableIndexedCollection tables)
         {
             // finalize the normal sequence tables
-            if (OutputType.Package == this.OutputType && !this.TreatProductAsModule)
+            if (OutputType.Package == this.OutputType)
             {
                 foreach (SequenceTable sequenceTable in Enum.GetValues(typeof(SequenceTable)))
                 {
@@ -2039,7 +2039,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
                     }
                 }
             }
-            else if (OutputType.Module == this.OutputType || this.TreatProductAsModule) // finalize the Module sequence tables
+            else if (OutputType.Module == this.OutputType) // finalize the Module sequence tables
             {
                 foreach (SequenceTable sequenceTable in Enum.GetValues(typeof(SequenceTable)))
                 {

--- a/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerDecompiler.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerDecompiler.cs
@@ -92,8 +92,17 @@ namespace WixToolset.Core.WindowsInstaller
             var extractFilesFolder = context.SuppressExtractCabinets || (String.IsNullOrEmpty(context.CabinetExtractFolder) && String.IsNullOrEmpty(context.ExtractFolder)) ? null :
                 String.IsNullOrEmpty(context.CabinetExtractFolder) ? Path.Combine(context.ExtractFolder, "File") : context.CabinetExtractFolder;
 
-            var outputType = context.TreatProductAsModule ? OutputType.Module : context.DecompileType;
-            var unbindCommand = new UnbindDatabaseCommand(this.Messaging, backendHelper, fileSystem, pathResolver, context.DecompilePath, null, outputType, context.ExtractFolder, extractFilesFolder, context.IntermediateFolder, enableDemodularization: true, skipSummaryInfo: false);
+            // IWindowsInstallerDecompileContext.TreatProductAsModule is broken. So broken, in fact,
+            // that it's been broken since WiX v3.0 in 2008. It was introduced (according to lore)
+            // to support Melt, which decompiles merge modules into fragments so you can consume
+            // merge modules without actually going through the black box that is mergemod.dll. But
+            // the name is wrong: It's not TreatProductAsModule; if anything it should instead be
+            // TreatModuleAsProduct, though even that's wrong (because you want a fragment, not a
+            // product/package). In WiX v5, rename to `KeepModularizeIds` (or something better) to
+            // reflect the functionality.
+            var demodularize = !context.TreatProductAsModule;
+            var sectionType = context.DecompileType;
+            var unbindCommand = new UnbindDatabaseCommand(this.Messaging, backendHelper, fileSystem, pathResolver, context.DecompilePath, null, sectionType, context.ExtractFolder, extractFilesFolder, context.IntermediateFolder, demodularize, skipSummaryInfo: false);
             var output = unbindCommand.Execute();
             var extractedFilePaths = unbindCommand.ExportedFiles;
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DecompileTargetDirMergeModule/ExpectedModularizationGuids.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DecompileTargetDirMergeModule/ExpectedModularizationGuids.wxs
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Module Codepage="65001" Id="MergeModule1.F844F0E3_8CB4_4A0F_973E_31C4F9338382" Language="1033" Version="1.0.0.0" InstallerVersion="200" Guid="{F844F0E3-8CB4-4A0F-973E-31C4F9338382}">
+    <Binary Id="Binary1.F844F0E3_8CB4_4A0F_973E_31C4F9338382" SourceFile="Expected.wxs" />
+    <Directory Id="ProgramFilesFolder.F844F0E3_8CB4_4A0F_973E_31C4F9338382" Name="PFiles">
+      <Directory Id="WixTestDir.F844F0E3_8CB4_4A0F_973E_31C4F9338382" ShortName="7bhhvaai" Name="WiX Toolset Test Directory">
+        <Component Id="ModuleComponent1.F844F0E3_8CB4_4A0F_973E_31C4F9338382" Guid="{D86EC5A2-9576-4699-BDC3-00586FF72CBE}" Bitness="always32">
+          <File Id="File1.F844F0E3_8CB4_4A0F_973E_31C4F9338382" ShortName="gahushls.wxs" Name="MergeModule.wxs" KeyPath="yes" Source="SourceDir\File\File1.F844F0E3_8CB4_4A0F_973E_31C4F9338382" />
+        </Component>
+      </Directory>
+    </Directory>
+    <Directory Id="MergeRedirectFolder.F844F0E3_8CB4_4A0F_973E_31C4F9338382">
+      <Component Id="ModuleComponent2.F844F0E3_8CB4_4A0F_973E_31C4F9338382" Guid="{BB222EE8-229B-4051-9443-49E348F0CC77}" Bitness="always32">
+        <File Id="File2.F844F0E3_8CB4_4A0F_973E_31C4F9338382" ShortName="sfmxqeab.wxs" Name="MergeModule.wxs" KeyPath="yes" Source="SourceDir\File\File2.F844F0E3_8CB4_4A0F_973E_31C4F9338382" />
+      </Component>
+    </Directory>
+    <SummaryInformation Description="MergeModule1" Manufacturer="WiX Toolset contributors" />
+    <StandardDirectory Id="TARGETDIR">
+      <Component Id="ModuleComponent3.F844F0E3_8CB4_4A0F_973E_31C4F9338382" Guid="{63A2B2B1-32BE-46FF-8863-4C85A2745F62}" Bitness="always32">
+        <RegistryValue KeyPath="yes" Id="Reg1.F844F0E3_8CB4_4A0F_973E_31C4F9338382" Root="HKLM" Key="SOFTWARE\WiX Toolset\MergeModuleDecompileTest" Name="DoesntReallyMatter" Value="Hello" Type="string" />
+      </Component>
+    </StandardDirectory>
+  </Module>
+</Wix>


### PR DESCRIPTION
IWindowsInstallerDecompileContext.TreatProductAsModule.

https://github.com/wixtoolset/issues/issues/7607