### PR TITLE
bump xunit to version 2.5.0

### DIFF
--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -86,12 +86,12 @@
   <!-- Keep the following versions in sync with internal\WixInternal.TestSupport.Native\packages.config -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
-    <PackageVersion Include="GitInfo" Version="2.2.0" />
+    <PackageVersion Include="GitInfo" Version="2.3.0" />
 
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageVersion Include="xunit.assert" Version="2.4.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
+    <PackageVersion Include="xunit" Version="2.5.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.0" />
+    <PackageVersion Include="xunit.assert" Version="2.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/internal/SetBuildNumber/SetBuildNumber.proj
+++ b/src/internal/SetBuildNumber/SetBuildNumber.proj
@@ -117,6 +117,6 @@
           BeforeTargets="AfterBuild" />
 
   <ItemGroup>
-    <PackageReference Include="GitInfo" Version="2.2.0" />
+    <PackageReference Include="GitInfo" Version="2.3.0" />
   </ItemGroup>
 </Project>

--- a/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.props
+++ b/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.props
@@ -5,8 +5,8 @@
   <PropertyGroup>
     <RepoRootDir Condition=" '$(RepoRootDir)' == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), .gitignore))</RepoRootDir>
   </PropertyGroup>
-  <Import Project="$(RepoRootDir)\packages\xunit.core.2.4.2\build\xunit.core.props" Condition="Exists('$(RepoRootDir)\packages\xunit.core.2.4.2\build\xunit.core.props')" />
-  <Import Project="$(RepoRootDir)\packages\xunit.runner.visualstudio.2.4.5\build\net462\xunit.runner.visualstudio.props" Condition="Exists('$(RepoRootDir)\packages\xunit.runner.visualstudio.2.4.5\build\net462\xunit.runner.visualstudio.props')" />
+  <Import Project="$(RepoRootDir)\packages\xunit.core.2.5.0\build\xunit.core.props" Condition="Exists('$(RepoRootDir)\packages\xunit.core.2.5.0\build\xunit.core.props')" />
+  <Import Project="$(RepoRootDir)\packages\xunit.runner.visualstudio.2.5.0\build\net462\xunit.runner.visualstudio.props" Condition="Exists('$(RepoRootDir)\packages\xunit.runner.visualstudio.2.5.0\build\net462\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>

--- a/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.targets
+++ b/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.targets
@@ -22,28 +22,28 @@
       <HintPath>$(RootPackagesFolder)xunit.abstractions.2.0.3\lib\netstandard2.0\xunit.abstractions.dll</HintPath>
     </Reference>
     <Reference Include="xunit.assert">
-      <HintPath>$(RootPackagesFolder)xunit.assert.2.4.2\lib\netstandard1.1\xunit.assert.dll</HintPath>
+      <HintPath>$(RootPackagesFolder)xunit.assert.2.5.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
     <Reference Include="xunit.core">
-      <HintPath>$(RootPackagesFolder)xunit.extensibility.core.2.4.2\lib\netstandard1.1\xunit.core.dll</HintPath>
+      <HintPath>$(RootPackagesFolder)xunit.extensibility.core.2.5.0\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
     <Reference Include="xunit.execution.desktop">
-      <HintPath>$(RootPackagesFolder)xunit.extensibility.execution.2.4.2\lib\net452\xunit.execution.desktop.dll</HintPath>
+      <HintPath>$(RootPackagesFolder)xunit.extensibility.execution.2.5.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
 
-  <Import Project="$(RootPackagesFolder)xunit.core.2.4.2\build\xunit.core.targets" Condition="Exists('$(RootPackagesFolder)xunit.core.2.4.2\build\xunit.core.targets')" />
+  <Import Project="$(RootPackagesFolder)xunit.core.2.5.0\build\xunit.core.targets" Condition="Exists('$(RootPackagesFolder)xunit.core.2.5.0\build\xunit.core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.4.2\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.4.2\build\xunit.core.props'))" />
-    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.4.2\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.4.2\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('$(RootPackagesFolder)xunit.runner.visualstudio.2.4.5\build\net462\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.runner.visualstudio.2.4.5\build\net462\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.5.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.5.0\build\xunit.core.props'))" />
+    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.5.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.5.0\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('$(RootPackagesFolder)xunit.runner.visualstudio.2.5.0\build\net462\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.runner.visualstudio.2.5.0\build\net462\xunit.runner.visualstudio.props'))" />
   </Target>
 
-  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.4.2\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x86" Condition=" '$(Platform)'!='x64' " />
-  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.4.2\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x64" Condition=" '$(Platform)'=='x64' " />
+  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.5.0\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x86" Condition=" '$(Platform)'!='x64' " />
+  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.5.0\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x64" Condition=" '$(Platform)'=='x64' " />
   <Target Name="Test">
     <!-- https://xunit.net/docs/running-tests-in-msbuild -->
     <!-- https://github.com/xunit/xunit/issues/2188 -->

--- a/src/internal/WixInternal.TestSupport.Native/packages.config
+++ b/src/internal/WixInternal.TestSupport.Native/packages.config
@@ -7,10 +7,10 @@
     when any of these versions are updated.
   -->
   <package id="xunit.abstractions" version="2.0.3" />
-  <package id="xunit.assert" version="2.4.2" />
-  <package id="xunit.core" version="2.4.2" />
-  <package id="xunit.extensibility.core" version="2.4.2" />
-  <package id="xunit.extensibility.execution" version="2.4.2" />
-  <package id="xunit.runner.msbuild" version="2.4.2" />
-  <package id="xunit.runner.visualstudio" version="2.4.5" />
+  <package id="xunit.assert" version="2.5.0" />
+  <package id="xunit.core" version="2.5.0" />
+  <package id="xunit.extensibility.core" version="2.5.0" />
+  <package id="xunit.extensibility.execution" version="2.5.0" />
+  <package id="xunit.runner.msbuild" version="2.5.0" />
+  <package id="xunit.runner.visualstudio" version="2.5.0" />
 </packages>

--- a/src/internal/WixInternal.TestSupport/XunitExtensions/WixAssert.cs
+++ b/src/internal/WixInternal.TestSupport/XunitExtensions/WixAssert.cs
@@ -91,7 +91,7 @@ namespace WixInternal.TestSupport
         {
             if (collection.Count > 0)
             {
-                Assert.True(false, $"The collection was expected to be empty, but instead was [{Environment.NewLine}\"{String.Join($"\", {Environment.NewLine}\"", collection)}\"{Environment.NewLine}]");
+                Assert.Fail($"The collection was expected to be empty, but instead was [{Environment.NewLine}\"{String.Join($"\", {Environment.NewLine}\"", collection)}\"{Environment.NewLine}]");
             }
         }
 

--- a/src/test/burn/WixTestTools/ArpEntryInstaller.cs
+++ b/src/test/burn/WixTestTools/ArpEntryInstaller.cs
@@ -31,7 +31,7 @@ namespace WixTestTools
             }
             else
             {
-                Assert.True(false, "Tried to unregister when not registered.");
+                Assert.Fail("Tried to unregister when not registered.");
             }
         }
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -152,7 +152,7 @@ namespace WixToolsetTest.CoreIntegration
                                 WixAssert.StringEqual("http://wixtoolset.org/schemas/v4/2008/Burn", attribute.Value);
                                 break;
                             default:
-                                Assert.False(true, $"Attribute: '{attribute.LocalName}', Value: '{attribute.Value}'");
+                                Assert.Fail($"Attribute: '{attribute.LocalName}', Value: '{attribute.Value}'");
                                 break;
                         }
                     }
@@ -264,7 +264,7 @@ namespace WixToolsetTest.CoreIntegration
                             WixAssert.StringEqual("http://wixtoolset.org/schemas/v4/2008/Burn", attribute.Value);
                             break;
                         default:
-                            Assert.False(true, $"Attribute: '{attribute.LocalName}', Value: '{attribute.Value}'");
+                            Assert.Fail($"Attribute: '{attribute.LocalName}', Value: '{attribute.Value}'");
                             break;
                     }
                 }
@@ -808,7 +808,7 @@ namespace WixToolsetTest.CoreIntegration
                     return;
                 }
 
-                Assert.False(true, "Expected exception not accepted.");
+                Assert.Fail("Expected exception not accepted.");
             }
         }
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/LinkerFixture.cs
@@ -109,7 +109,7 @@ namespace WixToolsetTest.CoreIntegration
                     return;
                 }
 
-                Assert.True(false, "Expected WixException for missing entry section but expectations were not met.");
+                Assert.Fail("Expected WixException for missing entry section but expectations were not met.");
             }
         }
 
@@ -139,7 +139,7 @@ namespace WixToolsetTest.CoreIntegration
                     return;
                 }
 
-                Assert.True(false, "Expected WixException for missing entry section but expectations were not met.");
+                Assert.Fail("Expected WixException for missing entry section but expectations were not met.");
             }
         }
 
@@ -169,7 +169,7 @@ namespace WixToolsetTest.CoreIntegration
                     return;
                 }
 
-                Assert.True(false, "Expected WixException for missing entry section but expectations were not met.");
+                Assert.Fail("Expected WixException for missing entry section but expectations were not met.");
             }
         }
     }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/PatchFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/PatchFixture.cs
@@ -575,7 +575,7 @@ namespace WixToolsetTest.CoreIntegration
             var args = $"/a \"{Path.ChangeExtension(msiPath, "msi")}\" TARGETDIR=\"{targetDir}\" /qn";
 
             var proc = Process.Start("msiexec.exe", args);
-            proc.WaitForExit(10000);
+            proc.WaitForExit(20000);
 
             Assert.Equal(0, proc.ExitCode);
         }


### PR DESCRIPTION
I've built the develop branch of wix a number of times over the last few days using the `devbuild.cmd`.
It built successfully half a dozen times on day one.
A unit test started failing (timing out) on day two.

Being new to building wix, I was unsure how this stopped working. I ended up updating the xunit nuget packages and extending the timeout.

Hope this is useful.

- updated xunit from 2.4.2 to 2.5.0
- updated GitInfo from 2.2.0 to 2.3.0

Fixed failing tests reported by xunit:
- replaced `Assert.True(false,` with `Assert.Fail`
- replaced `Assert.False(true,` with `Assert.Fail`

Increased timeout on `PatchFixture.CanBuildPatchFromAdminImage` test
This test was randomly failing for me, the 10 second timeout was not sufficient every time