### PR TITLE
Add support for unit testing multiple extensions

### DIFF
--- a/src/internal/WixInternal.TestSupport/Builder.cs
+++ b/src/internal/WixInternal.TestSupport/Builder.cs
@@ -11,14 +11,29 @@ namespace WixInternal.TestSupport
         public Builder(string sourceFolder, Type extensionType = null, string[] bindPaths = null, string outputFile = null)
         {
             this.SourceFolder = sourceFolder;
-            this.ExtensionType = extensionType;
+            if (extensionType != null)
+            {
+                this.ExtensionTypes = new Type[] { extensionType };
+            }
+            else
+            {
+                this.ExtensionTypes = new Type[] { };
+            }
+            this.BindPaths = bindPaths;
+            this.OutputFile = outputFile ?? "test.msi";
+        }
+
+        public Builder(string sourceFolder, Type[] extensionTypes, string[] bindPaths = null, string outputFile = null)
+        {
+            this.SourceFolder = sourceFolder;
+            this.ExtensionTypes = extensionTypes;
             this.BindPaths = bindPaths;
             this.OutputFile = outputFile ?? "test.msi";
         }
 
         public string[] BindPaths { get; set; }
 
-        public Type ExtensionType { get; set; }
+        public Type[] ExtensionTypes { get; set; }
 
         public string OutputFile { get; set; }
 
@@ -46,10 +61,10 @@ namespace WixInternal.TestSupport
                     "-intermediateFolder", intermediateFolder,
                 };
 
-                if (this.ExtensionType != null)
+                foreach (var ext in this.ExtensionTypes)
                 {
                     args.Add("-ext");
-                    args.Add(Path.GetFullPath(new Uri(this.ExtensionType.Assembly.CodeBase).LocalPath));
+                    args.Add(Path.GetFullPath(new Uri(ext.Assembly.CodeBase).LocalPath));
                 }
 
                 args.AddRange(sourceFiles);
@@ -108,10 +123,10 @@ namespace WixInternal.TestSupport
                     "-intermediateFolder", intermediateFolder,
                 };
 
-                if (this.ExtensionType != null)
+                foreach (var ext in this.ExtensionTypes)
                 {
                     firstBuildArgs.Add("-ext");
-                    firstBuildArgs.Add(Path.GetFullPath(new Uri(this.ExtensionType.Assembly.CodeBase).LocalPath));
+                    firstBuildArgs.Add(Path.GetFullPath(new Uri(ext.Assembly.CodeBase).LocalPath));
                 }
 
                 firstBuildArgs.AddRange(sourceFiles);
@@ -140,10 +155,10 @@ namespace WixInternal.TestSupport
                     "-o", decompilePath
                 };
 
-                if (this.ExtensionType != null)
+                foreach (var ext in this.ExtensionTypes)
                 {
                     decompileArgs.Add("-ext");
-                    decompileArgs.Add(Path.GetFullPath(new Uri(this.ExtensionType.Assembly.CodeBase).LocalPath));
+                    decompileArgs.Add(Path.GetFullPath(new Uri(ext.Assembly.CodeBase).LocalPath));
                 }
 
                 decompileFunc(decompileArgs.ToArray());
@@ -157,10 +172,10 @@ namespace WixInternal.TestSupport
                     "-intermediateFolder", decompileIntermediateFolder
                 };
 
-                if (this.ExtensionType != null)
+                foreach (var ext in this.ExtensionTypes)
                 {
                     secondBuildArgs.Add("-ext");
-                    secondBuildArgs.Add(Path.GetFullPath(new Uri(this.ExtensionType.Assembly.CodeBase).LocalPath));
+                    secondBuildArgs.Add(Path.GetFullPath(new Uri(ext.Assembly.CodeBase).LocalPath));
                 }
 
                 secondBuildArgs.Add("-bindpath");

--- a/src/wix/test/WixToolsetTest.CoreIntegration/DependencyExtensionFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/DependencyExtensionFixture.cs
@@ -2,6 +2,7 @@
 
 namespace WixToolsetTest.CoreIntegration
 {
+    using System;
     using System.Collections.Generic;
     using System.IO;
     using System.Linq;
@@ -152,7 +153,7 @@ namespace WixToolsetTest.CoreIntegration
         public void CanBuildPackageUsingProvides()
         {
             var folder = TestData.Get(@"TestData\UsingProvides");
-            var build = new Builder(folder, null, new[] { folder });
+            var build = new Builder(folder, new Type[] { }, new[] { folder });
 
             var results = build.BuildAndQuery(Build, "Wix4DependencyProvider");
             WixAssert.CompareLineByLine(new[]

--- a/src/wix/test/WixToolsetTest.CoreIntegration/SoftwareTagFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/SoftwareTagFixture.cs
@@ -2,6 +2,7 @@
 
 namespace WixToolsetTest.CoreIntegration
 {
+    using System;
     using System.IO;
     using System.Linq;
     using System.Xml.Linq;
@@ -19,7 +20,7 @@ namespace WixToolsetTest.CoreIntegration
         public void CanBuildPackageWithTag()
         {
             var folder = TestData.Get(@"TestData\ProductTag");
-            var build = new Builder(folder, null, new[] { folder });
+            var build = new Builder(folder, new Type[] { }, new[] { folder });
 
             var results = build.BuildAndQuery(Build, "File", "SoftwareIdentificationTag");
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
@@ -2,6 +2,7 @@
 
 namespace WixToolsetTest.CoreIntegration
 {
+    using System;
     using System.IO;
     using System.Linq;
     using WixInternal.TestSupport;
@@ -45,7 +46,7 @@ namespace WixToolsetTest.CoreIntegration
         public void MajorUpgradeDowngradeMessagePopulatesRowsAsExpected()
         {
             var folder = TestData.Get("TestData", "Upgrade");
-            var build = new Builder(folder, null, new[] { folder });
+            var build = new Builder(folder, new Type[] { }, new[] { folder });
 
             var results = build.BuildAndQuery(Build, "Upgrade", "LaunchCondition");
             WixAssert.CompareLineByLine(new[]


### PR DESCRIPTION
Added a constructor that takes an array of types, so integration between multiple extensions can be tested.

Fixed an error that showed up after adding the new constructor, because passing `null` as the 2nd argument was ambiguous.
![ambiguous-constructor](https://github.com/wixtoolset/wix/assets/1804713/83a32398-dc7f-442e-b877-f1f0d9199ce9)


Example package file:
![image](https://github.com/wixtoolset/wix/assets/1804713/02a4fbe6-ce8a-4505-9572-4cf03d0836ff)

Example unit test file:
![image](https://github.com/wixtoolset/wix/assets/1804713/c01989de-6fa6-4868-9a64-b0e64c995ae5)
