### PR TITLE
Remove legacy permissions support.

### DIFF
--- a/src/ext/Util/ca/scasmb.h
+++ b/src/ext/Util/ca/scasmb.h
@@ -23,14 +23,11 @@ struct SCA_SMB  // hungarian ss
 	WCHAR wzDirectory[MAX_PATH + 1];
 
 	int nUserPermissionCount;
-	int nPermissions;
 	SCA_SMB_EX_USER_PERMS* pExUserPerms;
 
 	INSTALLSTATE isInstalled, isAction;
 
 	BOOL fUseIntegratedAuth;
-	BOOL fLegacyUserProvided;
-	struct SCA_USER scau;
 
 	struct SCA_SMB* pssNext;
 };


### PR DESCRIPTION
In the long ago, a share could have one user/permissions pair. That's really limited, of course, so support for _n_ user/permissions pairs was added. In the move to WiX v4, support for that single, legacy user was removed from the extension side but not the custom action side. Remove that support.

Fixes https://github.com/wixtoolset/issues/issues/7632.

Triage for v4.0.2.