### PR TITLE
Fix stack corruption around cbdata when adding a machine certificate

### DIFF
--- a/src/ext/Iis/ca/scacertexec.cpp
+++ b/src/ext/Iis/ca/scacertexec.cpp
@@ -154,7 +154,7 @@ static HRESULT ExecuteCertificateOperation(
     LPWSTR pwzPFXPassword = NULL;
     LPWSTR pwzFilePath = NULL;
     BYTE* pbData = NULL;
-    DWORD cbData = 0;
+    DWORD_PTR cbData = 0;
     DWORD_PTR cbPFXPassword = 0;
 
     BOOL fUserStoreLocation = (CERT_SYSTEM_STORE_CURRENT_USER == dwStoreLocation);
@@ -174,7 +174,7 @@ static HRESULT ExecuteCertificateOperation(
     ExitOnFailure(hr, "Failed to parse certificate attribute");
     if (SCA_ACTION_INSTALL == saAction) // install operations need more data
     {
-        hr = WcaReadStreamFromCaData(&pwz, &pbData, (DWORD_PTR*)&cbData);
+        hr = WcaReadStreamFromCaData(&pwz, &pbData, &cbData);
         ExitOnFailure(hr, "Failed to parse certificate stream.");
 
         hr = WcaReadStringFromCaData(&pwz, &pwzPFXPassword);
@@ -192,7 +192,7 @@ static HRESULT ExecuteCertificateOperation(
         // CertAddCertificateContextToStore(CERT_STORE_ADD_REPLACE_EXISTING) does not remove the private key if the cert is replaced
         UninstallCertificatePackage(hCertStore, fUserStoreLocation, pwzName);
 
-        hr = InstallCertificatePackage(hCertStore, fUserStoreLocation, pwzName, pbData, cbData, iAttributes & SCA_CERT_ATTRIBUTE_VITAL, pwzPFXPassword);
+        hr = InstallCertificatePackage(hCertStore, fUserStoreLocation, pwzName, pbData, (DWORD)cbData, iAttributes & SCA_CERT_ATTRIBUTE_VITAL, pwzPFXPassword);
         ExitOnFailure(hr, "Failed to install certificate.");
     }
     else


### PR DESCRIPTION
Adding a machine certificate calls into `WcaReadStreamFromCaData(&pwz, &pbData, (DWORD_PTR*)&cbData);`

`WcaReadStreamFromCaData` writes to `DWORD_PTR` which is larger than the `DWORD cbData` allocated on the stack, so memory of `cbPFXPassword` is temporarily corrupted
Then `cbPFXPassword` is overwritten by a call to `WcaReadStringFromCaData(&pwz, &pwzPFXPassword)`

![Capture1](https://github.com/wixtoolset/wix/assets/1804713/1d8517ed-5ff6-44c9-827d-ac8bff6d4c00)


![Capture2](https://github.com/wixtoolset/wix/assets/1804713/c70fea0a-71cc-4114-ab02-d44f8008bcc8)

No stack corruption is reported after this change