### PR TITLE
Ensure the Font actions are scheduled for TrueType fonts

### DIFF
--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
@@ -678,6 +678,8 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             attributes |= (symbol.Attributes & FileSymbolAttributes.Vital) == FileSymbolAttributes.Vital ? WindowsInstallerConstants.MsidbFileAttributesVital : 0;
             row.Attributes = attributes;
 
+            // Note that TrueType fonts are denoted by the empty string in the FontTitle
+            // field. So, non-null means a font is present.
             if (symbol.FontTitle != null)
             {
                 var fontRow = this.CreateRow(symbol, "Font");

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/SequenceActionsCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/SequenceActionsCommand.cs
@@ -446,7 +446,9 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                         var foundBindPath = false;
                         foreach (var file in this.Section.Symbols.OfType<FileSymbol>())
                         {
-                            if (!foundFont && !String.IsNullOrEmpty(file.FontTitle))
+                            // Note that TrueType fonts are denoted by the empty string in the FontTitle
+                            // field. So, non-null means a font is present.
+                            if (!foundFont && file.FontTitle != null)
                             {
                                 set.Add("InstallExecuteSequence/RegisterFonts");
                                 set.Add("InstallExecuteSequence/UnregisterFonts");

--- a/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
@@ -488,11 +488,13 @@ namespace WixToolsetTest.CoreIntegration
                 result.AssertSuccess();
 
                 Assert.True(File.Exists(msiPath));
-                var results = Query.QueryDatabase(msiPath, new[] { "Font" });
+                var results = Query.QueryDatabase(msiPath, new[] { "Font", "InstallExecuteSequence" });
                 WixAssert.CompareLineByLine(new[]
                 {
                     "Font:test.txt\tFakeFont",
-                }, results);
+                    "InstallExecuteSequence:RegisterFonts\t\t5300",
+                    "InstallExecuteSequence:UnregisterFonts\t\t2500",
+                }, results.Where(l => l.Contains("Font")).ToArray());
             }
         }
 
@@ -521,11 +523,13 @@ namespace WixToolsetTest.CoreIntegration
                 result.AssertSuccess();
 
                 Assert.True(File.Exists(msiPath));
-                var results = Query.QueryDatabase(msiPath, new[] { "Font" });
+                var results = Query.QueryDatabase(msiPath, new[] { "Font", "InstallExecuteSequence" });
                 WixAssert.CompareLineByLine(new[]
                 {
                     "Font:TrueTypeFontFile\t",
-                }, results);
+                    "InstallExecuteSequence:RegisterFonts\t\t5300",
+                    "InstallExecuteSequence:UnregisterFonts\t\t2500",
+                }, results.Where(l => l.Contains("Font")).ToArray());
             }
         }
 


### PR DESCRIPTION
TrueType fonts are denoted by the empty string in the FontTitle field of the FileSymbol. That means a non-null FontTitle field value means a font is being installed.

Fixes wixtoolset/issues#7593