### PR TITLE
Fix the use of ModuleSubstitution table

### DIFF
--- a/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerTableDefinitions.cs
+++ b/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerTableDefinitions.cs
@@ -1455,7 +1455,7 @@ namespace WixToolset.Data.WindowsInstaller
             SymbolDefinitions.ModuleConfiguration,
             new[]
             {
-                new ColumnDefinition("Name", ColumnType.String, 72, primaryKey: true, nullable: false, ColumnCategory.Identifier, description: "Unique identifier for this row."),
+                new ColumnDefinition("Name", ColumnType.String, 72, primaryKey: true, nullable: false, ColumnCategory.Identifier, description: "Unique identifier for this row.", modularizeType: ColumnModularizeType.None),
                 new ColumnDefinition("Format", ColumnType.Number, 2, primaryKey: false, nullable: false, ColumnCategory.Unknown, minValue: 0, maxValue: 3, description: "Format of this item."),
                 new ColumnDefinition("Type", ColumnType.String, 72, primaryKey: false, nullable: true, ColumnCategory.Text, description: "Additional type information for this item."),
                 new ColumnDefinition("ContextData", ColumnType.Localized, 0, primaryKey: false, nullable: true, ColumnCategory.Text, description: "Additional context information about this item."),

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
@@ -58,7 +58,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
 
         private IWindowsInstallerBackendHelper WindowsInstallerBackendHelper { get; }
 
-        private  IFileSystem FileSystem { get; }
+        private IFileSystem FileSystem { get; }
 
         private IPathResolver PathResolver { get; }
 
@@ -477,7 +477,10 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 var command = new MergeModulesCommand(this.Messaging, this.WindowsInstallerBackendHelper, fileFacadesFromModule, section, suppressedTableNames, this.OutputPath, this.IntermediateFolder);
                 command.Execute();
 
-                trackedFiles.AddRange(command.TrackedFiles);
+                if (command.TrackedFiles != null)
+                {
+                    trackedFiles.AddRange(command.TrackedFiles);
+                }
             }
 
             if (this.Messaging.EncounteredError)

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
@@ -148,6 +148,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                         break;
 
                     case SymbolDefinitionType.ModuleSubstitution:
+                        this.AddSymbolDefaultly(symbol);
                         this.EnsureModuleIgnoredTable(symbol, "ModuleSubstitution");
                         break;
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Module/MergeModuleSubstitution.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Module/MergeModuleSubstitution.wxs
@@ -1,0 +1,17 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MergeModuleSubstitution" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade message" />
+
+        <Feature Id="Main">
+            <MergeRef Id="TestMsm" />
+        </Feature>
+
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage">
+                <Merge Id="TestMsm" Language="1033" SourceFile="test.msm">
+                    <ConfigurationData Name="CONFIGTEST" Value="TestingTesting123" />
+                </Merge>
+            </Directory>
+        </StandardDirectory>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Module/ModuleSubstitution.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Module/ModuleSubstitution.wxs
@@ -1,0 +1,11 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Module Id="MergeModule.v4" Guid="dc68e039-e0c8-49fb-b5e6-37f9569188e5" Language="1033" Version="1.0.0.0">
+    <SummaryInformation Manufacturer="Manufacturer" />
+
+    <Configuration Name='CONFIGTEST' Format='Text'/>
+    <Substitution Table='CustomAction' Row='setCONFIGTEST' Column='Target' Value='[=CONFIGTEST]'/>
+
+    <Property Id="msmCONFIGTEST" Value="failure"/>
+    <CustomAction Id='setCONFIGTEST' Property='msmCONFIGTEST' Value='[msmCONFIGTEST]'/>
+  </Module>
+</Wix>


### PR DESCRIPTION
Addresses two issues in the creation of configurable merge modules. First, the ModuleConfiguration table Id should not be modularized. Second, the ModuleSubstitution table was never created. Fixing both of those allows configurable merge modules to work again.

Fixes 7559