### PR TITLE
Use WcaGetRecordFormattedString to get firewall rule description

### DIFF
--- a/src/ext/Firewall/ca/firewall.cpp
+++ b/src/ext/Firewall/ca/firewall.cpp
@@ -79,7 +79,7 @@ static UINT SchedFirewallExceptions(
         hr = WcaGetRecordString(hRec, feqComponent, &pwzComponent);
         ExitOnFailure(hr, "Failed to get firewall exception component.");
 
-        hr = WcaGetRecordString(hRec, feqDescription, &pwzDescription);
+        hr = WcaGetRecordFormattedString(hRec, feqDescription, &pwzDescription);
         ExitOnFailure(hr, "Failed to get firewall exception description.");
 
         hr = WcaGetRecordInteger(hRec, feqDirection, &iDirection);

--- a/src/test/burn/WixTestTools/Firewall/RuleDetails.cs
+++ b/src/test/burn/WixTestTools/Firewall/RuleDetails.cs
@@ -164,7 +164,7 @@ namespace WixTestTools.Firewall
         public bool? Enabled { get; set; }
 
         /// <summary>
-        /// This property is optional. It specifies the group to which an individual rule belongs and groups multiple rules into a single line in the Windows Firewall control panel<br/>
+        /// This property is optional. It specifies the group to which an individual rule belongs and groups multiple rules into a single line in the Windows Firewall control panel.<br/>
         /// This allows the users to enable or disable multiple rules with a single click.<br/>
         /// The Grouping property can also be specified using indirect strings.<br/>
         /// Example: "Simple Group Name"<br/>
@@ -193,7 +193,7 @@ namespace WixTestTools.Firewall
 
         /// <summary>
         /// This property is optional. The NET_FW_ACTION enumerated type specifies the action for this rule.<br/>
-        /// NET_FW_ACTION_ALLOW is the default value. Profiles can be combined from the following values:<br/>
+        /// NET_FW_ACTION_ALLOW is the default value. The Action must be specified from the following list of values:<br/>
         /// <b>o</b> NET_FW_ACTION_BLOCK = 0x0<br/>
         /// <b>o</b> NET_FW_ACTION_ALLOW = 0x1<br/>
         /// </summary>

--- a/src/test/burn/WixTestTools/Firewall/UniqueCheck.cs
+++ b/src/test/burn/WixTestTools/Firewall/UniqueCheck.cs
@@ -6,7 +6,7 @@ namespace WixTestTools.Firewall
 
     /// <summary>
     /// A lot of firewall rules don't follow the Microsoft recommendation of using unique names.<br/>
-    /// This class helps to disambiguate the rules based on Name, Direction, Profile, Protocol, ApplicationName and the LocalUserOwner.
+    /// This class helps to disambiguate the rules based on Name, Direction, Profile, Protocol, ApplicationName, LocalUserOwner and RemoteAddresses.
     /// </summary>
     public class UniqueCheck
     {
@@ -22,6 +22,7 @@ namespace WixTestTools.Firewall
             this.Protocol = details.Protocol;
             this.ApplicationName = details.ApplicationName;
             this.LocalUserOwner = details.LocalUserOwner;
+            this.RemoteAddresses = details.RemoteAddresses;
         }
 
 
@@ -37,6 +38,7 @@ namespace WixTestTools.Firewall
 
         public string LocalUserOwner { get; set; }
 
+        public string RemoteAddresses { get; set; }
 
         public bool FirewallRuleIsUnique(INetFwRule3 rule)
         {
@@ -66,6 +68,11 @@ namespace WixTestTools.Firewall
             }
 
             if (this.LocalUserOwner != null && rule.LocalUserOwner != this.LocalUserOwner)
+            {
+                return false;
+            }
+
+            if (this.RemoteAddresses != null && rule.RemoteAddresses != this.RemoteAddresses)
             {
                 return false;
             }

--- a/src/test/burn/WixTestTools/Firewall/Verifier.cs
+++ b/src/test/burn/WixTestTools/Firewall/Verifier.cs
@@ -281,7 +281,9 @@ namespace WixTestTools.Firewall
             Assert.True(expected.ServiceName == actual.ServiceName, FormatErrorMessage(name, "ServiceNames", expected.ServiceName, actual.ServiceName, unique));
             Assert.True(expected.Protocol == actual.Protocol, FormatErrorMessage(name, "Protocols", expected.Protocol, actual.Protocol, unique));
             Assert.True(expected.LocalPorts == actual.LocalPorts, FormatErrorMessage(name, "LocalPorts", expected.LocalPorts, actual.LocalPorts, unique));
+            Assert.True(expected.LocalAddresses == actual.LocalAddresses, FormatErrorMessage(name, "LocalAddresses", expected.LocalAddresses, actual.LocalAddresses, unique));
             Assert.True(expected.RemotePorts == actual.RemotePorts, FormatErrorMessage(name, "RemotePorts", expected.RemotePorts, actual.RemotePorts, unique));
+            Assert.True(expected.RemoteAddresses == actual.RemoteAddresses, FormatErrorMessage(name, "RemoteAddresses", expected.RemoteAddresses, actual.RemoteAddresses, unique));
             Assert.True(expected.IcmpTypesAndCodes == actual.IcmpTypesAndCodes, FormatErrorMessage(name, "IcmpTypesAndCodes", expected.IcmpTypesAndCodes, actual.Description, unique));
             Assert.True(expected.Direction == actual.Direction, FormatErrorMessage(name, "Directions", expected.Direction, actual.Direction, unique));
             Assert.Equal<object>(expected.Interfaces, actual.Interfaces);

--- a/src/test/msi/TestData/FirewallExtensionTests/DynamicFirewallRules/DynamicFirewallRules.wixproj
+++ b/src/test/msi/TestData/FirewallExtensionTests/DynamicFirewallRules/DynamicFirewallRules.wixproj
@@ -1,0 +1,13 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<Project Sdk="WixToolset.Sdk">
+  <PropertyGroup>
+    <UpgradeCode>{C587F355-26FF-4D17-801F-50505C348D99}</UpgradeCode>
+    <ProductComponentsRef>true</ProductComponentsRef>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Templates\Product.wxs" Link="Product.wxs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Firewall.wixext" />
+  </ItemGroup>
+</Project>

--- a/src/test/msi/TestData/FirewallExtensionTests/DynamicFirewallRules/product.wxs
+++ b/src/test/msi/TestData/FirewallExtensionTests/DynamicFirewallRules/product.wxs
@@ -1,0 +1,50 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:fw="http://wixtoolset.org/schemas/v4/wxs/firewall">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <ComponentRef Id="FirewallComponent2"/>
+        </ComponentGroup>
+
+		<Property Id="PORTNUMBER" Secure="yes">
+			<RegistrySearch Id="FindPortNumber" Root="HKLM" Key="SOFTWARE\WiX\Tests\$(var.TestGroupName)" Name="PortNumber" Type="raw" />
+		</Property>
+
+		<CustomAction Id="SavePortNumberCmdLineValue" Property="CMDLINE_PORTNUMBER" Value="[PORTNUMBER]" Execute="firstSequence" />
+		<CustomAction Id="SetPortNumberFromCmdLineValue" Property="PORTNUMBER" Value="[CMDLINE_PORTNUMBER]" Execute="firstSequence" />
+		<CustomAction Id="SetPortNumberDefaultValue" Property="PORTNUMBER" Value="9999" Execute="firstSequence" />
+
+		<InstallExecuteSequence>
+		  <Custom Action="SavePortNumberCmdLineValue" Before="AppSearch" />
+		  <Custom Action="SetPortNumberFromCmdLineValue" After="AppSearch" Condition="CMDLINE_PORTNUMBER" />
+		  <Custom Action="SetPortNumberDefaultValue" After="SetPortNumberFromCmdLineValue" Condition="NOT PORTNUMBER" />
+		</InstallExecuteSequence>
+    </Fragment>
+
+    <Fragment>
+        <Component Id="FirewallComponent2" Guid="528C212C-09C6-47FC-A466-A3799DD04D25" Directory="INSTALLFOLDER" >
+			<RegistryValue Root="HKLM" Key="SOFTWARE\WiX\Tests\$(var.TestGroupName)" Name="PortNumber" Value="[PORTNUMBER]" Type="string" />
+
+            <File Source="$(sys.SOURCEFILEPATH)" KeyPath="yes" >
+                <fw:FirewallException Id="FirewallException1"
+					Port="[PORTNUMBER]"
+                    Description="WiX Toolset firewall exception rule integration test - dynamic app description [PORTNUMBER]"
+                    Name="WiXToolset401 Test - 0003" Scope="localSubnet" />
+            </File>
+			
+            <fw:FirewallException Id="FirewallException2"
+                Description="WiX Toolset firewall exception rule integration test - dynamic port description [PORTNUMBER]"
+                Name="WiXToolset401 Test - 0004" Scope="any" Port="[PORTNUMBER]" />
+
+            <fw:FirewallException Id="FirewallException3"
+                Description="WiX Toolset firewall exception rule integration test - dynamic Name [PORTNUMBER]"
+				Program="%windir%\system32\[PORTNUMBER].exe"
+				Port="[PORTNUMBER]"
+				Protocol="udp" Profile="private"
+                Name="WiXToolset401 Test - 0005 - [PORTNUMBER]" >
+				<fw:RemoteAddress Value="127.0.0.1" />
+				<fw:RemoteAddress Value="192.168.1.1" />
+			</fw:FirewallException>
+        </Component>
+    </Fragment>
+</Wix>

--- a/src/test/msi/WixToolsetTest.MsiE2E/FirewallExtensionTests.cs
+++ b/src/test/msi/WixToolsetTest.MsiE2E/FirewallExtensionTests.cs
@@ -200,5 +200,82 @@ namespace WixToolsetTest.MsiE2E
 
             Verifier.VerifyFirewallRule("WiXToolset401 Test - 0001", expected);
         }
+
+        [RuntimeFact]
+        public void FirewallRulesUseFormattedStringProperties()
+        {
+            var product = this.CreatePackageInstaller("DynamicFirewallRules");
+            product.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+
+            var expected1 = new RuleDetails("WiXToolset401 Test - 0003")
+            {
+                Action = NET_FW_ACTION_.NET_FW_ACTION_ALLOW,
+                ApplicationName = this.TestContext.GetTestInstallFolder(false, Path.Combine("DynamicFirewallRules", "product.wxs")),
+                Description = "WiX Toolset firewall exception rule integration test - dynamic app description 9999",
+                Direction = NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_IN,
+                EdgeTraversal = true,
+                EdgeTraversalOptions = 1,
+                Enabled = true,
+                InterfaceTypes = "All",
+                LocalAddresses = "*",
+                Profiles = Int32.MaxValue,
+                Protocol = 6,
+                RemoteAddresses = "LocalSubnet",
+                SecureFlags = 0,
+                LocalPorts = "9999",
+                RemotePorts = "*",
+            };
+
+            Verifier.VerifyFirewallRule("WiXToolset401 Test - 0003", expected1);
+
+            var expected2 = new RuleDetails("WiXToolset401 Test - 0004")
+            {
+                Action = NET_FW_ACTION_.NET_FW_ACTION_ALLOW,
+                Description = "WiX Toolset firewall exception rule integration test - dynamic port description 9999",
+                Direction = NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_IN,
+                EdgeTraversal = false,
+                EdgeTraversalOptions = 0,
+                Enabled = true,
+                InterfaceTypes = "All",
+                LocalAddresses = "*",
+                Profiles = Int32.MaxValue,
+                Protocol = 6,
+                RemoteAddresses = "*",
+                SecureFlags = 0,
+                LocalPorts = "9999",
+                RemotePorts = "*",
+            };
+
+            Verifier.VerifyFirewallRule("WiXToolset401 Test - 0004", expected2);
+
+
+            var expected3 = new RuleDetails("WiXToolset401 Test - 0005 - 9999")
+            {
+                Action = NET_FW_ACTION_.NET_FW_ACTION_ALLOW,
+                ApplicationName = Path.Combine(Environment.GetEnvironmentVariable("windir"), "system32", "9999.exe"),
+                Description = "WiX Toolset firewall exception rule integration test - dynamic Name 9999",
+                Direction = NET_FW_RULE_DIRECTION_.NET_FW_RULE_DIR_IN,
+                EdgeTraversal = true,
+                EdgeTraversalOptions = 1,
+                Enabled = true,
+                InterfaceTypes = "All",
+                LocalAddresses = "*",
+                Profiles = 2,
+                Protocol = 17,
+                RemoteAddresses = "127.0.0.1/255.255.255.255,192.168.1.1/255.255.255.255",
+                SecureFlags = 0,
+                LocalPorts = "9999",
+                RemotePorts = "*",
+            };
+
+            Verifier.VerifyFirewallRule("WiXToolset401 Test - 0005 - 9999", expected3);
+
+            product.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+
+            // verify the firewall exceptions have been removed.
+            Assert.False(Verifier.FirewallRuleExists("WiXToolset401 Test - 0003"));
+            Assert.False(Verifier.FirewallRuleExists("WiXToolset401 Test - 0004"));
+            Assert.False(Verifier.FirewallRuleExists("WiXToolset401 Test - 0005 - 9999"));
+        }
     }
 }


### PR DESCRIPTION
- The [column definition](https://github.com/wixtoolset/wix/blob/develop/src/ext/Firewall/wixext/FirewallTableDefinitions.cs#L23) for the Description says it's a formatted string, but it was retrieved as a plain string
- fixed a few typos in the comments
- added missing RemoteAddresses and LocalAddresses assert
- added integration test for using formatted properties