### PR TITLE
Add assembly redirects for cross version integration tests

### DIFF
--- a/nuget.config
+++ b/nuget.config
@@ -12,6 +12,7 @@
   <packageSourceMapping>
     <packageSource key="nuget">
       <package pattern="*" />
+      <package pattern="WixToolset.*" allowedVersions="[,{GitBaseVersionMajor})" />
     </packageSource>
     <packageSource key="build">
       <package pattern="WixToolset.*" />

--- a/src/internal/SetBuildNumber/SetBuildNumber.proj
+++ b/src/internal/SetBuildNumber/SetBuildNumber.proj
@@ -22,14 +22,33 @@
       GitThisAssembly;
       SetGlobalJson;
       SetDirectoryPackagesProps;
-      SetOverallWixVersions
+      SetOverallWixVersions;
+      TransformWixAppConfig
     </SetBuildNumbersDependsOn>
 
     <GlobalJsonPath>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\..\..\global.json))</GlobalJsonPath>
     <CentralPackageVersionsPath>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\..\..\Directory.Packages.props))</CentralPackageVersionsPath>
     <OverallWixVersionsPath>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\..\..\build\wixver.props))</OverallWixVersionsPath>
     <GitInfoThisAssemblyFile>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\..\..\build\ThisAssembly.WixVer.cs))</GitInfoThisAssemblyFile>
+    <WixAppConfigTransform>$([System.IO.Path]::GetFullPath($(MSBuildThisFileDirectory)..\..\wix\wix\app.config))</WixAppConfigTransform>
   </PropertyGroup>
+
+  <Target Name="TransformWixAppConfig"
+          Inputs="transform.wix.app.config"
+          Outputs="$(WixAppConfigTransform)">
+    <PropertyGroup>
+	  <OverallWixAppConfigHeader></OverallWixAppConfigHeader>
+      <OverallWixAppConfigText>$([System.IO.File]::ReadAllText(transform.wix.app.config))</OverallWixAppConfigText>
+      <OverallWixAppConfigText>$(OverallWixAppConfigText.Replace('{GitBaseVersionMajor}', $(GitBaseVersionMajor)))</OverallWixAppConfigText>
+    </PropertyGroup>
+
+    <WriteLinesToFile File="$(WixAppConfigTransform)"
+                      Lines="$(OverallWixAppConfigHeader);$(OverallWixAppConfigText)"
+					  WriteOnlyWhenDifferent="true"
+                      Overwrite="true" />
+
+    <Message Importance="high" Text="$(MSBuildProjectName) -&gt; $(WixAppConfigTransform)" />
+  </Target>
 
   <Target Name="SetGlobalJson"
           Inputs="global.json.pp"
@@ -50,7 +69,7 @@
 
     <WriteLinesToFile File="$(GlobalJsonPath)"
                       Lines="$(GlobaJsonTextHeader);$(GlobalJsonText)"
-                      Overwrite="true" 
+                      Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
 
     <Message Importance="high" Text="$(MSBuildProjectName) -&gt; $(GlobalJsonPath)" />
@@ -74,7 +93,7 @@
 
     <WriteLinesToFile File="$(CentralPackageVersionsPath)"
                       Lines="$(CentralPackageVersionsTextHeader);$(CentralPackageVersionsText)"
-                      Overwrite="true" 
+                      Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
 
     <Message Importance="high" Text="$(MSBuildProjectName) -&gt; $(CentralPackageVersionsPath)" />
@@ -98,7 +117,7 @@
 
     <WriteLinesToFile File="$(OverallWixVersionsPath)"
                       Lines="$(OverallWixVersionsTextHeader);$(OverallWixVersionsText)"
-                      Overwrite="true" 
+                      Overwrite="true"
                       WriteOnlyWhenDifferent="true" />
 
     <Message Importance="high" Text="$(MSBuildProjectName) -&gt; $(OverallWixVersionsPath)" />

--- a/src/internal/SetBuildNumber/transform.wix.app.config
+++ b/src/internal/SetBuildNumber/transform.wix.app.config
@@ -7,11 +7,11 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="WixToolset.Extensibility" publicKeyToken="a7d136314861246c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-{GitBaseVersionMajor}.0.0.0" newVersion="{GitBaseVersionMajor}.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="WixToolset.Data" publicKeyToken="a7d136314861246c" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-{GitBaseVersionMajor}.0.0.0" newVersion="{GitBaseVersionMajor}.0.0.0" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>


### PR DESCRIPTION
I encountered a few issues before I was able to build V4 and V5 test projects together.

A module merge test will follow, but I thought this might be handy in a separate commit, in case it needs to be undone for some reason later on.

- `nuget.config` change loads `WixToolset.*` < v5 from nuget, but uses the local packages from the build folder for the v5 being built.
- assembly redirects are required when a project references other projects with a wildcard (eg. `<ProjectReference Include="**\*.wixproj" />` in [`TestData.proj`](https://github.com/wixtoolset/wix/blob/develop/src/test/msi/TestData/TestData.proj#L6)) and some of those projects are different versions.

**Before nuget.config change**
![unabletofindpackage](https://github.com/wixtoolset/wix/assets/1804713/61f10801-f4ca-475f-8413-b3dfd63c5320)

**Before assembly redirects were added**
![cannotload1](https://github.com/wixtoolset/wix/assets/1804713/4a79bb55-89c7-4a9c-b9c9-acac2ec2550c)
![cannotload2](https://github.com/wixtoolset/wix/assets/1804713/860074e4-1688-4df9-bdf2-d8562bc0abfa)
