### PR TITLE
Correctly process build -outputType switch

### DIFF
--- a/src/test/burn/TestData/DependencyTests/PatchA/PatchA.wixproj
+++ b/src/test/burn/TestData/DependencyTests/PatchA/PatchA.wixproj
@@ -1,7 +1,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project Sdk="WixToolset.Sdk">
   <PropertyGroup>
-    <OutputType>PatchCreation</OutputType>
+    <OutputType>Patch</OutputType>
     <TargetExt>.msp</TargetExt>
     <SuppressSpecificWarnings>1079</SuppressSpecificWarnings>
   </PropertyGroup>

--- a/src/test/burn/TestData/DependencyTests/PatchB/PatchB.wixproj
+++ b/src/test/burn/TestData/DependencyTests/PatchB/PatchB.wixproj
@@ -1,7 +1,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project Sdk="WixToolset.Sdk">
   <PropertyGroup>
-    <OutputType>PatchCreation</OutputType>
+    <OutputType>Patch</OutputType>
     <TargetExt>.msp</TargetExt>
     <SuppressSpecificWarnings>1079</SuppressSpecificWarnings>
   </PropertyGroup>

--- a/src/test/burn/TestData/PatchTests/PatchA2/PatchA2.wixproj
+++ b/src/test/burn/TestData/PatchTests/PatchA2/PatchA2.wixproj
@@ -1,7 +1,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project Sdk="WixToolset.Sdk">
   <PropertyGroup>
-    <OutputType>PatchCreation</OutputType>
+    <OutputType>Patch</OutputType>
     <TargetExt>.msp</TargetExt>
     <SuppressSpecificWarnings>1079</SuppressSpecificWarnings>
   </PropertyGroup>

--- a/src/test/burn/TestData/SlipstreamTests/PatchA/PatchA.wixproj
+++ b/src/test/burn/TestData/SlipstreamTests/PatchA/PatchA.wixproj
@@ -1,7 +1,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project Sdk="WixToolset.Sdk">
   <PropertyGroup>
-    <OutputType>PatchCreation</OutputType>
+    <OutputType>Patch</OutputType>
     <TargetExt>.msp</TargetExt>
     <SuppressSpecificWarnings>1079</SuppressSpecificWarnings>
   </PropertyGroup>

--- a/src/test/burn/TestData/SlipstreamTests/PatchAB/PatchAB.wixproj
+++ b/src/test/burn/TestData/SlipstreamTests/PatchAB/PatchAB.wixproj
@@ -1,7 +1,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project Sdk="WixToolset.Sdk">
   <PropertyGroup>
-    <OutputType>PatchCreation</OutputType>
+    <OutputType>Patch</OutputType>
     <TargetExt>.msp</TargetExt>
     <SuppressSpecificWarnings>1079</SuppressSpecificWarnings>
   </PropertyGroup>

--- a/src/test/burn/TestData/SlipstreamTests/PatchAB2/PatchAB2.wixproj
+++ b/src/test/burn/TestData/SlipstreamTests/PatchAB2/PatchAB2.wixproj
@@ -1,7 +1,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project Sdk="WixToolset.Sdk">
   <PropertyGroup>
-    <OutputType>PatchCreation</OutputType>
+    <OutputType>Patch</OutputType>
     <TargetExt>.msp</TargetExt>
     <SuppressSpecificWarnings>1079</SuppressSpecificWarnings>
   </PropertyGroup>

--- a/src/wix/WixToolset.Core.Burn/BurnBackendFactory.cs
+++ b/src/wix/WixToolset.Core.Burn/BurnBackendFactory.cs
@@ -18,6 +18,7 @@ namespace WixToolset.Core.Burn
             switch (outputType.ToLowerInvariant())
             {
                 case "bundle":
+                case "burn":
                 case ".exe":
                     backend = new BundleBackend();
                     return true;

--- a/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerBackendFactory.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerBackendFactory.cs
@@ -18,6 +18,7 @@ namespace WixToolset.Core.WindowsInstaller
             switch (outputType?.ToLowerInvariant())
             {
                 case "module":
+                case "msm":
                 case ".msm":
                     backend = new MsmBackend();
                     return true;
@@ -25,11 +26,14 @@ namespace WixToolset.Core.WindowsInstaller
                 case "msipackage":
                 case "package":
                 case "product":
+                case "msi":
                 case ".msi":
                     backend = new MsiBackend();
                     return true;
 
+                case "msppackage":
                 case "patch":
+                case "msp":
                 case ".msp":
                     backend = new MspBackend();
                     return true;

--- a/src/wix/WixToolset.Core/BindContext.cs
+++ b/src/wix/WixToolset.Core/BindContext.cs
@@ -42,6 +42,8 @@ namespace WixToolset.Core
 
         public string OutputPath { get; set; }
 
+        public string OutputType { get; set; }
+
         public PdbType PdbType { get; set; }
 
         public string PdbPath { get; set; }

--- a/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -316,6 +316,11 @@ namespace WixToolset.Core.CommandLine
                     context.PdbPath = inputsOutputs.PdbPath;
                     context.CancellationToken = cancellationToken;
 
+                    if (context is BindContext bindContext)
+                    {
+                        bindContext.OutputType = this.commandLine.OutputType;
+                    }
+
                     var binder = this.ServiceProvider.GetService<IBinder>();
                     bindResult = binder.Bind(context);
                 }

--- a/src/wix/WixToolset.Core/CoreErrors.cs
+++ b/src/wix/WixToolset.Core/CoreErrors.cs
@@ -26,6 +26,11 @@ namespace WixToolset.Core
             return Message(sourceLineNumbers, Ids.UnableToOpenFile, "Unable to open file: {0}. Error detail: {1}", path, detail);
         }
 
+        public static Message BackendNotFound(string outputType, string outputPath)
+        {
+            return Message(null, Ids.BackendNotFound, "Unable to find a backend to process output type: {0} for output file: {1}. Specify a different output type or output file extension.", outputType, outputPath);
+        }
+
         private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
         {
             return new Message(sourceLineNumber, MessageLevel.Error, (int)id, format, args);
@@ -37,6 +42,7 @@ namespace WixToolset.Core
             UnableToDeleteFile = 7011,
             UnableToMoveFile = 7012,
             UnableToOpenFile = 7013,
+            BackendNotFound = 7014,
         } // last available is 7099. 7100 is WindowsInstallerBackendWarnings.
     }
 }


### PR DESCRIPTION
Also, add a few additional output types to built-in backends.

Fixes wixtoolset/issues#7708 in v4.0.2