### PR TITLE
Naked files and default feature

### DIFF
--- a/src/api/wix/WixToolset.Data/ErrorMessages.cs
+++ b/src/api/wix/WixToolset.Data/ErrorMessages.cs
@@ -2271,6 +2271,11 @@ namespace WixToolset.Data
             return Message(sourceLineNumbers, Ids.IllegalInnerText, "The {0} element contains inner text which is obsolete. Use the {1} attribute instead.", elementName, attributeName);
         }
 
+        public static Message IllegalAttributeWhenNested(SourceLineNumber sourceLineNumbers, string attributeName)
+        {
+            return Message(sourceLineNumbers, Ids.IllegalAttributeWhenNested, "The File element contains an attribute '{0}' that cannot be used in a File element that is a child of a Component element.", attributeName);
+        }
+
         private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
         {
             return new Message(sourceLineNumber, MessageLevel.Error, (int)id, format, args);

--- a/src/wix/WixToolset.Core/AssignDefaultFeatureCommand.cs
+++ b/src/wix/WixToolset.Core/AssignDefaultFeatureCommand.cs
@@ -8,7 +8,6 @@ namespace WixToolset.Core
     using WixToolset.Data;
     using WixToolset.Data.Symbols;
     using WixToolset.Extensibility.Services;
-    using static System.Collections.Specialized.BitVector32;
 
     internal class AssignDefaultFeatureCommand
     {

--- a/src/wix/WixToolset.Core/AssignDefaultFeatureCommand.cs
+++ b/src/wix/WixToolset.Core/AssignDefaultFeatureCommand.cs
@@ -1,0 +1,70 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using WixToolset.Core.Link;
+    using WixToolset.Data;
+    using WixToolset.Data.Symbols;
+    using WixToolset.Extensibility.Services;
+    using static System.Collections.Specialized.BitVector32;
+
+    internal class AssignDefaultFeatureCommand
+    {
+        private const string DefaultFeatureName = "WixDefaultFeature";
+
+        public AssignDefaultFeatureCommand(IMessaging messaging, IntermediateSection entrySection, IEnumerable<IntermediateSection> sections, HashSet<string> referencedComponents, Link.ConnectToFeatureCollection componentsToFeatures)
+        {
+            this.Messaging = messaging;
+            this.EntrySection = entrySection;
+            this.Sections = sections;
+            this.ReferencedComponents = referencedComponents;
+            this.ComponentsToFeatures = componentsToFeatures;
+        }
+
+        public IMessaging Messaging { get; }
+
+        public IntermediateSection EntrySection { get; }
+
+        public IEnumerable<IntermediateSection> Sections { get; }
+
+        public HashSet<string> ReferencedComponents { get; }
+
+        public ConnectToFeatureCollection ComponentsToFeatures { get; }
+
+        public void Execute()
+        {
+            var assignedComponents = false;
+
+            foreach (var section in this.Sections)
+            {
+                foreach (var component in section.Symbols.OfType<ComponentSymbol>().ToList())
+                {
+                    if (!this.ReferencedComponents.Contains(component.Id.Id))
+                    {
+                        assignedComponents = true;
+
+                        this.ComponentsToFeatures.Add(new ConnectToFeature(section, component.Id.Id, DefaultFeatureName, explicitPrimaryFeature: true));
+
+                        section.AddSymbol(new FeatureComponentsSymbol
+                        {
+                            FeatureRef = DefaultFeatureName,
+                            ComponentRef = component.Id.Id,
+                        });
+                    }
+                }
+            }
+
+            if (assignedComponents)
+            {
+                this.EntrySection.AddSymbol(new FeatureSymbol(null, new Identifier(AccessModifier.Global, DefaultFeatureName))
+                {
+                    Level = 1,
+                    Display = 0,
+                    InstallDefault = FeatureInstallDefault.Local,
+                });
+            }
+        }
+    }
+}

--- a/src/wix/WixToolset.Core/Compiler.cs
+++ b/src/wix/WixToolset.Core/Compiler.cs
@@ -2681,7 +2681,7 @@ namespace WixToolset.Core
         /// <param name="parentLanguage">Optional language of parent (only useful for Modules).</param>
         private void ParseComponentGroupRefElement(XElement node, ComplexReferenceParentType parentType, string parentId, string parentLanguage)
         {
-            Debug.Assert(ComplexReferenceParentType.ComponentGroup == parentType || ComplexReferenceParentType.FeatureGroup == parentType || ComplexReferenceParentType.Feature == parentType || ComplexReferenceParentType.Module == parentType);
+            Debug.Assert(ComplexReferenceParentType.ComponentGroup == parentType || ComplexReferenceParentType.FeatureGroup == parentType || ComplexReferenceParentType.Feature == parentType || ComplexReferenceParentType.Module == parentType || ComplexReferenceParentType.Product == parentType);
 
             var sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
             string id = null;
@@ -2730,7 +2730,7 @@ namespace WixToolset.Core
         /// <param name="parentLanguage">Optional language of parent (only useful for Modules).</param>
         private void ParseComponentRefElement(XElement node, ComplexReferenceParentType parentType, string parentId, string parentLanguage)
         {
-            Debug.Assert(ComplexReferenceParentType.FeatureGroup == parentType || ComplexReferenceParentType.ComponentGroup == parentType || ComplexReferenceParentType.Feature == parentType || ComplexReferenceParentType.Module == parentType);
+            Debug.Assert(ComplexReferenceParentType.FeatureGroup == parentType || ComplexReferenceParentType.ComponentGroup == parentType || ComplexReferenceParentType.Feature == parentType || ComplexReferenceParentType.Module == parentType || ComplexReferenceParentType.Product == parentType);
 
             var sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
             string id = null;

--- a/src/wix/WixToolset.Core/Compiler_Module.cs
+++ b/src/wix/WixToolset.Core/Compiler_Module.cs
@@ -175,6 +175,9 @@ namespace WixToolset.Core
                         case "Exclusion":
                             this.ParseExclusionElement(child);
                             break;
+                        case "File":
+                            this.ParseNakedFileElement(child, ComplexReferenceParentType.Module, this.activeName, null, null);
+                            break;
                         case "Icon":
                             this.ParseIconElement(child);
                             break;

--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -242,8 +242,14 @@ namespace WixToolset.Core
                         case "Component":
                             this.ParseComponentElement(child, ComplexReferenceParentType.Unknown, null, null, CompilerConstants.IntegerNotSet, null, null);
                             break;
+                        case "ComponentRef":
+                            this.ParseComponentRefElement(child, ComplexReferenceParentType.Product, null, null);
+                            break;
                         case "ComponentGroup":
                             this.ParseComponentGroupElement(child, ComplexReferenceParentType.Unknown, null);
+                            break;
+                        case "ComponentGroupRef":
+                            this.ParseComponentGroupRefElement(child, ComplexReferenceParentType.Product, null, null);
                             break;
                         case "CustomAction":
                             this.ParseCustomActionElement(child);

--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -287,6 +287,9 @@ namespace WixToolset.Core
                         case "FeatureGroupRef":
                             this.ParseFeatureGroupRefElement(child, ComplexReferenceParentType.Product, productCode);
                             break;
+                        case "File":
+                            this.ParseNakedFileElement(child, ComplexReferenceParentType.Unknown, null, null, null);
+                            break;
                         case "Icon":
                             this.ParseIconElement(child);
                             break;

--- a/src/wix/WixToolset.Core/Linker.cs
+++ b/src/wix/WixToolset.Core/Linker.cs
@@ -162,7 +162,7 @@ namespace WixToolset.Core
                         }
                     }
                 }
-                else
+                else if (find.EntrySection.Type == SectionType.Package)
                 {
                     var command = new AssignDefaultFeatureCommand(this.Messaging, find.EntrySection, sections, referencedComponents, componentsToFeatures);
                     command.Execute();

--- a/src/wix/test/WixToolsetTest.CoreIntegration/FeatureFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/FeatureFixture.cs
@@ -45,6 +45,77 @@ namespace WixToolsetTest.CoreIntegration
         }
 
         [Fact]
+        public void CanAutomaticallyCreateDefaultFeature()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Feature", "PackageDefaultFeature.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                Assert.Empty(result.Messages);
+
+                Assert.True(File.Exists(msiPath));
+                var results = Query.QueryDatabase(msiPath, new[] { "Feature", "FeatureComponents", "Shortcut" });
+                WixAssert.CompareLineByLine(new[]
+                {
+                    "Feature:WixDefaultFeature\t\t\t\t0\t1\t\t0",
+                    "FeatureComponents:WixDefaultFeature\tAnotherComponentInAFragment",
+                    "FeatureComponents:WixDefaultFeature\tComponentInAFragment",
+                    "FeatureComponents:WixDefaultFeature\tfil6J6CHYPBCOMYclNjnqn0afimmzM",
+                    "FeatureComponents:WixDefaultFeature\tfilcV1yrx0x8wJWj4qMzcH21jwkPko",
+                    "FeatureComponents:WixDefaultFeature\tfilj.cb0sFWqIPHPFSKJSEEaPDuAQ4",
+                    "Shortcut:AdvertisedShortcut\tINSTALLFOLDER\tShortcut\tAnotherComponentInAFragment\tWixDefaultFeature\t\t\t\t\t\t\t\t\t\t\t",
+                }, results);
+            }
+        }
+
+        [Fact]
+        public void WontAutomaticallyCreateDefaultFeature()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Feature", "PackageBadDefaultFeature.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                var messages = result.Messages.Select(m => m.ToString()).ToList();
+                messages.Sort();
+
+                WixAssert.CompareLineByLine(new[]
+                {
+                    "Found orphaned Component 'fil6J6CHYPBCOMYclNjnqn0afimmzM'. If this is a Package, every Component must have at least one parent Feature. To include a Component in a Module, you must include it directly as a Component element of the Module element or indirectly via ComponentRef, ComponentGroup, or ComponentGroupRef elements.",
+                    "Found orphaned Component 'filcV1yrx0x8wJWj4qMzcH21jwkPko'. If this is a Package, every Component must have at least one parent Feature. To include a Component in a Module, you must include it directly as a Component element of the Module element or indirectly via ComponentRef, ComponentGroup, or ComponentGroupRef elements.",
+                    "Found orphaned Component 'filj.cb0sFWqIPHPFSKJSEEaPDuAQ4'. If this is a Package, every Component must have at least one parent Feature. To include a Component in a Module, you must include it directly as a Component element of the Module element or indirectly via ComponentRef, ComponentGroup, or ComponentGroupRef elements.",
+                }, messages.ToArray());
+
+                Assert.Equal(267, result.ExitCode);
+            }
+        }
+
+        [Fact]
         public void CannotBuildMsiWithTooLargeFeatureDepth()
         {
             var folder = TestData.Get(@"TestData");

--- a/src/wix/test/WixToolsetTest.CoreIntegration/NakedFileFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/NakedFileFixture.cs
@@ -1,0 +1,240 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.Data;
+    using System.IO;
+    using System.Linq;
+    using WixInternal.Core.TestPackage;
+    using WixInternal.TestSupport;
+    using Xunit;
+
+    public class NakedFileFixture
+    {
+        [Fact]
+        public void CanBuildNakedFilesInComponentGroup()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("ComponentGroup.wxs");
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFilesInFeature()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("Feature.wxs");
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFilesInDirectory()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("Directory.wxs");
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFilesInDirectoryRef()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("DirectoryRef.wxs");
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFilesInFeatureRef()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("FeatureRef.wxs");
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFilesInFeatureGroup()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("FeatureGroup.wxs");
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFilesInFragments()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("Fragment.wxs");
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFilesInStandardDirectory()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("StandardDirectory.wxs");
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFilesInModule()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("Module.wxs", isPackage: false);
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFileInModuleWithFragments()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("ModuleFragment.wxs", isPackage: false);
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        [Fact]
+        public void CanBuildNakedFilesWithConditions()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("Condition.wxs");
+            var componentRows = rows.Where(row => row.StartsWith("Component:")).ToArray();
+
+            // Coincidentally, the files' ids are the same as the component conditions.
+            foreach (var componentRow in componentRows)
+            {
+                var columns = componentRow.Split(':', '\t');
+                Assert.Equal(columns[1], columns[5]);
+            }
+        }
+
+        [Fact]
+        public void NakedFilesUnderPackageWithAuthoredFeatureAreOrphaned()
+        {
+            var messages = BuildAndQueryComponentAndFileTables("PackageWithoutDefaultFeature.wxs", isPackage: true, 267);
+            Assert.Equal(new[]
+            {
+                "267",
+                "267",
+            }, messages);
+        }
+
+        [Fact]
+        public void IllegalAttributesWhenNonNakedFailTheBuild()
+        {
+            var messages = BuildAndQueryComponentAndFileTables("BadAttributes.wxs", isPackage: true, 62);
+            Assert.Equal(new[]
+            {
+                "62",
+                "62",
+                "62",
+                "62",
+            }, messages);
+        }
+
+        [Fact]
+        public void CanBuildNakedFileFromWixlibComponentGroup()
+        {
+            var rows = BuildPackageWithWixlib("WixlibComponentGroup.wxs", "WixlibComponentGroupPackage.wxs");
+
+            AssertFileComponentIds(2, rows);
+        }
+
+        private static string[] BuildPackageWithWixlib(string wixlibSourcePath, string msiSourcePath)
+        {
+            var folder = TestData.Get("TestData", "NakedFile");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var binFolder = Path.Combine(baseFolder, "bin");
+                var wixlibPath = Path.Combine(binFolder, Path.ChangeExtension(wixlibSourcePath, ".wixlib"));
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, wixlibSourcePath),
+                    "-intermediateFolder", intermediateFolder,
+                    "-bindpath", folder,
+                    "-o", wixlibPath,
+                });
+
+                result.AssertSuccess();
+
+                var msiPath = Path.Combine(binFolder, "test.msi");
+
+                result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, msiSourcePath),
+                    wixlibPath,
+                    "-intermediateFolder", intermediateFolder,
+                    "-bindpath", folder,
+                    "-o", msiPath,
+                });
+                result.AssertSuccess();
+
+                return Query.QueryDatabase(msiPath, new[] { "Component", "File" })
+                    .OrderBy(s => s)
+                    .ToArray();
+            }
+        }
+
+        private static string[] BuildAndQueryComponentAndFileTables(string file, bool isPackage = true, int? exitCode = null)
+        {
+            var folder = TestData.Get("TestData", "NakedFile");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var binFolder = Path.Combine(baseFolder, "bin");
+                var msiPath = Path.Combine(binFolder, isPackage ? "test.msi" : "test.msm");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, file),
+                    "-intermediateFolder", intermediateFolder,
+                    "-bindpath", folder,
+                    "-o", msiPath,
+                });
+
+                if (exitCode.HasValue)
+                {
+                    Assert.Equal(exitCode.Value, result.ExitCode);
+
+                    return result.Messages.Select(m => m.Id.ToString()).ToArray();
+                }
+                else
+                {
+                    result.AssertSuccess();
+
+                    return Query.QueryDatabase(msiPath, new[] { "Component", "File" })
+                        .OrderBy(s => s)
+                        .ToArray();
+                }
+            }
+        }
+
+        private static void AssertFileComponentIds(int fileCount, string[] rows)
+        {
+            var componentRows = rows.Where(row => row.StartsWith("Component:")).ToArray();
+            var fileRows = rows.Where(row => row.StartsWith("File:")).ToArray();
+
+            Assert.Equal(fileCount, componentRows.Length);
+            Assert.Equal(componentRows.Length, fileRows.Length);
+
+            // Component id == Component keypath == File id
+            foreach (var componentRow in componentRows)
+            {
+                var columns = componentRow.Split(':', '\t');
+                Assert.Equal(columns[1], columns[6]);
+            }
+
+            foreach (var fileRow in fileRows)
+            {
+                var columns = fileRow.Split(':', '\t');
+                Assert.Equal(columns[1], columns[2]);
+            }
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Feature/PackageBadDefaultFeature.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Feature/PackageBadDefaultFeature.wxs
@@ -1,0 +1,27 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="PackageMissingFeatureComponentMapping" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="12E4699F-E774-4D05-8A01-5BDD41BBA127">
+        <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+
+        <StandardDirectory Id="ProgramFiles6432Folder">
+            <Directory Id="INSTALLFOLDER" Name="PackageMissingFeatureComponentMapping">
+                <Directory Id="SubFolder" Name="NotMapped">
+                    <Component>
+                        <File Source="test.txt" />
+                    </Component>
+                </Directory>
+            </Directory>
+        </StandardDirectory>
+
+        <Feature Id="MissingComponentFeature" />
+        
+        <Component Directory="INSTALLFOLDER">
+            <File Source="test.txt" />
+        </Component>
+
+        <ComponentGroup Id="ImplicitFeatureComponentGroup" Directory="INSTALLFOLDER">
+            <Component>
+                <File Name="test2.txt" Source="test.txt" />
+            </Component>
+        </ComponentGroup>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Feature/PackageDefaultFeature.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Feature/PackageDefaultFeature.wxs
@@ -1,0 +1,46 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="PackageMissingFeatureComponentMapping" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="12E4699F-E774-4D05-8A01-5BDD41BBA127">
+        <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+
+        <StandardDirectory Id="ProgramFiles6432Folder">
+            <Directory Id="INSTALLFOLDER" Name="PackageMissingFeatureComponentMapping">
+                <Directory Id="SubFolder" Name="NotMapped">
+                    <Component>
+                        <File Source="test.txt" />
+                    </Component>
+                </Directory>
+            </Directory>
+        </StandardDirectory>
+
+        <Component Directory="INSTALLFOLDER">
+            <File Source="test.txt" />
+        </Component>
+
+        <ComponentRef Id="ComponentInAFragment" />
+        <ComponentGroupRef Id="ComponentGroupInAFragment" />
+        <FeatureGroupRef Id="FeatureGroupInAFragment" />
+    </Package>
+
+    <Fragment>
+        <ComponentGroup Id="ComponentGroupInAFragment" Directory="INSTALLFOLDER">
+            <Component>
+                <File Name="test2.txt" Source="test.txt" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+
+    <Fragment>
+        <FeatureGroup Id="FeatureGroupInAFragment" />
+
+        <Component Id="AnotherComponentInAFragment" Directory="INSTALLFOLDER">
+            <File Name="test3.txt" Source="test.txt" />
+            <Shortcut Id="AdvertisedShortcut" Advertise="yes" Name="Shortcut" />
+        </Component>
+    </Fragment>
+
+    <Fragment>
+        <Component Id="ComponentInAFragment" Directory="INSTALLFOLDER">
+            <File Name="test4.txt" Source="test.txt" />
+        </Component>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/BadAttributes.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/BadAttributes.wxs
@@ -1,0 +1,11 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <Feature Id="ProductFeature">
+      <Component Directory="ProgramFilesFolder" Subdirectory="MsiPackage">
+        <File Source="test.txt" Bitness="always64" Condition="BLAHBLAHBLAH" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" />
+      </Component>
+    </Feature>
+  </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/ComponentGroup.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/ComponentGroup.wxs
@@ -1,0 +1,14 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <Feature Id="ProductFeature">
+      <ComponentGroupRef Id="Files" />
+    </Feature>
+    
+    <ComponentGroup Id="Files" Directory="ProgramFilesFolder" Subdirectory="MsiPackage">
+      <File Source="test.txt" />
+      <File Source="test.txt" Name="test2.txt" />
+    </ComponentGroup>
+  </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Condition.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Condition.wxs
@@ -1,0 +1,10 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <Feature Id="ProductFeature">
+      <File Id="FILE1" Condition="FILE1" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" />
+      <File Id="FILE2" Condition="FILE2" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" Name="test2.txt" />
+    </Feature>
+  </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Directory.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Directory.wxs
@@ -1,0 +1,13 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage">
+        <!-- Relies on default-feature feature to include naked files in package. -->
+        <File Id="test.txt" Source="test.txt" />
+        <File Id="test2.txt" Source="test.txt" Name="test2.txt" />
+      </Directory>
+    </StandardDirectory>
+  </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/DirectoryRef.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/DirectoryRef.wxs
@@ -1,0 +1,17 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <DirectoryRef Id="INSTALLFOLDER">
+      <!-- Relies on default-feature feature to include naked files in package. -->
+      <File Id="test.txt" Source="test.txt" />
+      <File Id="test2.txt" Source="test.txt" Name="test2.txt" />
+    </DirectoryRef>
+  </Package>
+  
+  <Fragment>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Feature.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Feature.wxs
@@ -1,0 +1,10 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <Feature Id="ProductFeature">
+      <File Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" />
+      <File Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" Name="test2.txt" />
+    </Feature>
+  </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/FeatureGroup.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/FeatureGroup.wxs
@@ -1,0 +1,22 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <Feature Id="ProductFeature">
+      <FeatureGroupRef Id="ProductFeatureGroup" />
+    </Feature>
+  </Package>
+  
+  <Fragment>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
+  </Fragment>
+  
+  <Fragment>
+    <FeatureGroup Id="ProductFeatureGroup">
+      <File Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" />
+      <File Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" Name="test2.txt" />
+    </FeatureGroup>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/FeatureRef.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/FeatureRef.wxs
@@ -1,0 +1,20 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <FeatureRef Id="ProductFeature">
+      <File Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" />
+      <File Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" Name="test2.txt" />
+    </FeatureRef>
+  </Package>
+  
+  <Fragment>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
+  </Fragment>
+  
+  <Fragment>
+    <Feature Id="ProductFeature" />
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Fragment.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Fragment.wxs
@@ -1,0 +1,24 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <FeatureGroupRef Id="FeatureGroup1" />
+    <FeatureGroupRef Id="FeatureGroup2" />
+  </Package>
+  
+  <Fragment>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+    </StandardDirectory>
+  </Fragment>
+  
+  <Fragment>
+    <FeatureGroup Id="FeatureGroup1" />
+    <File Id="test.txt" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" />
+  </Fragment>
+  
+  <Fragment>
+    <FeatureGroup Id="FeatureGroup2" />
+    <File Id="test2.txt" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" Name="test2.txt" />
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Module.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Module.wxs
@@ -1,0 +1,6 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Module Id="MergeModule" Guid="e535b765-1019-4a4f-b3ea-ae28870e6d73" Language="1033" Version="1.0.0.0">
+    <File Id="FILE1" Condition="FILE1" Directory="ProgramFilesFolder" Subdirectory="MergeModule" Source="test.txt" />
+    <File Id="FILE2" Condition="FILE2" Directory="ProgramFilesFolder" Subdirectory="MergeModule" Source="test.txt" Name="test2.txt" />
+  </Module>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/ModuleFragment.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/ModuleFragment.wxs
@@ -1,0 +1,16 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Module Id="MergeModule" Guid="e535b765-1019-4a4f-b3ea-ae28870e6d73" Language="1033" Version="1.0.0.0">
+    <PropertyRef Id="MergeModuleProperty1" />
+    <PropertyRef Id="MergeModuleProperty2" />
+  </Module>
+   
+  <Fragment>
+    <Property Id="MergeModuleProperty1" Hidden="yes" />
+    <File Id="test.txt" Directory="ProgramFilesFolder" Subdirectory="MergeModule" Source="test.txt" />
+  </Fragment>
+  
+  <Fragment>
+    <Property Id="MergeModuleProperty2" Hidden="yes" />
+    <File Id="test2.txt" Directory="ProgramFilesFolder" Subdirectory="MergeModule" Source="test.txt" Name="test2.txt" />
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/PackageWithoutDefaultFeature.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/PackageWithoutDefaultFeature.wxs
@@ -1,0 +1,17 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <File Source="test.txt" Name="test3.txt" />
+        <File Source="test.txt" Name="test4.txt" />
+
+        <Feature Id="ProductFeature">
+            <ComponentGroupRef Id="Files" />
+        </Feature>
+
+        <ComponentGroup Id="Files" Directory="ProgramFilesFolder" Subdirectory="MsiPackage">
+            <File Source="test.txt" />
+            <File Source="test.txt" Name="test2.txt" />
+        </ComponentGroup>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/StandardDirectory.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/StandardDirectory.wxs
@@ -1,0 +1,11 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+    <StandardDirectory Id="ProgramFilesFolder">
+      <!-- Relies on default-feature feature to include naked files in package. -->
+      <File Id="test.txt" Source="test.txt" />
+      <File Id="test2.txt" Source="test.txt" Name="test2.txt" />
+    </StandardDirectory>
+  </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/WixlibComponentGroup.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/WixlibComponentGroup.wxs
@@ -1,0 +1,14 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+
+    <Fragment>
+        <ComponentGroup Id="WixlibFiles">
+            <File Id="test.txt" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" />
+            <File Id="test2.txt" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="test.txt" Name="test2.txt" />
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/WixlibComponentGroupPackage.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/WixlibComponentGroupPackage.wxs
@@ -1,0 +1,6 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+    <ComponentGroupRef Id="WixlibFiles" />
+  </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/test.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/test.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/PackageComponents.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SingleFile/PackageComponents.wxs
@@ -2,9 +2,8 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Fragment>
         <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
-            <Component>
-                <File Source="test.txt" />
-            </Component>
+            <File Source="test.txt" />
+            
             <Component Id="Shared.dll" Shared="yes">
                 <File Name="Shared.dll" Source="test.txt" />
             </Component>


### PR DESCRIPTION
Implements https://github.com/wixtoolset/issues/issues/7696.
Implements https://github.com/wixtoolset/issues/issues/7581.

`File` elements can appear where `Component` elements do in WiX v4. The
compiler generates an appropriate per-file component. Naked files under
`Directory`, `DirectoryRef`, `Fragment`, `StandardDirectory`, or
`Package` elements are included in a package via the [default-feature
feature](https://github.com/wixtoolset/issues/issues/7581). Naked files
appearing under `ComponentGroup`, `Feature`, `FeatureRef`, and
`FeatureGroup` generate the component and the reference to the parent
element.

