### PR TITLE
Introduce a new phase in the build pipeline.

### DIFF
--- a/src/api/wix/WixToolset.Extensibility/BaseOptimizerExtension.cs
+++ b/src/api/wix/WixToolset.Extensibility/BaseOptimizerExtension.cs
@@ -1,0 +1,26 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Extensibility
+{
+    using WixToolset.Extensibility.Data;
+
+    /// <summary>
+    /// Base class for creating an optimizer extension.
+    /// </summary>
+    public abstract class BaseOptimizerExtension : IOptimizerExtension
+    {
+        /// <summary>
+        /// Called after all files have been compiled, before built-in optimizations, and before all sections are linked into a single section.
+        /// </summary>
+        public virtual void PreOptimize(IOptimizeContext context)
+        {
+        }
+
+        /// <summary>
+        /// Called after all files have been compiled, after built-in optimizations, and before all sections are linked into a single section.
+        /// </summary>
+        public virtual void PostOptimize(IOptimizeContext context)
+        {
+        }
+    }
+}

--- a/src/api/wix/WixToolset.Extensibility/Data/ICompileContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/ICompileContext.cs
@@ -55,7 +55,7 @@ namespace WixToolset.Extensibility.Data
         XDocument Source { get; set; }
 
         /// <summary>
-        /// Cancellation token to abort cancellation.
+        /// Cancellation token.
         /// </summary>
         CancellationToken CancellationToken { get; set; }
     }

--- a/src/api/wix/WixToolset.Extensibility/Data/IOptimizeContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/IOptimizeContext.cs
@@ -1,0 +1,61 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Extensibility.Data
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using WixToolset.Data;
+
+    /// <summary>
+    /// Context provided to the optimizer.
+    /// </summary>
+    public interface IOptimizeContext
+    {
+        /// <summary>
+        /// Service provider made available to the optimizer and its extensions.
+        /// </summary>
+        IServiceProvider ServiceProvider { get; }
+
+        /// <summary>
+        /// Set of extensions provided to the optimizer.
+        /// </summary>
+        IReadOnlyCollection<IOptimizerExtension> Extensions { get; set; }
+
+        /// <summary>
+        /// Intermediate folder.
+        /// </summary>
+        string IntermediateFolder { get; set; }
+
+        /// <summary>
+        /// Collection of bindpaths used to bind files.
+        /// </summary>
+        IReadOnlyCollection<IBindPath> BindPaths { get; set; }
+
+        /// <summary>
+        /// Bind variables used during optimization.
+        /// </summary>
+        IDictionary<string, string> BindVariables { get; set; }
+
+        /// <summary>
+        /// Gets or sets the platform which the optimizer will use when defaulting 64-bit symbol properties.
+        /// </summary>
+        /// <value>The platform which the optimizer will use when defaulting 64-bit symbol properties.</value>
+        Platform Platform { get; set; }
+
+        /// <summary>
+        /// Collection of intermediates to optimize.
+        /// </summary>
+        IReadOnlyCollection<Intermediate> Intermediates { get; set; }
+
+        /// <summary>
+        /// Collection of localization files to use in the optimizer.
+        /// </summary>
+        IReadOnlyCollection<Localization> Localizations { get; set; }
+
+        /// <summary>
+        /// Cancellation token.
+        /// </summary>
+        CancellationToken CancellationToken { get; set; }
+    }
+}

--- a/src/api/wix/WixToolset.Extensibility/IOptimizerExtension.cs
+++ b/src/api/wix/WixToolset.Extensibility/IOptimizerExtension.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Extensibility
+{
+    using WixToolset.Extensibility.Data;
+
+    /// <summary>
+    /// Interface that all optimizer extensions implement.
+    /// </summary>
+    public interface IOptimizerExtension
+    {
+        /// <summary>
+        /// Called after all files have been compiled, before built-in optimizations, and before all sections are linked into a single section.
+        /// </summary>
+        void PreOptimize(IOptimizeContext context);
+
+        /// <summary>
+        /// Called after all files have been compiled, after built-in optimizations, and before all sections are linked into a single section.
+        /// </summary>
+        void PostOptimize(IOptimizeContext context);
+    }
+}

--- a/src/wix/WixToolset.Core/IOptimizer.cs
+++ b/src/wix/WixToolset.Core/IOptimizer.cs
@@ -1,0 +1,17 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core
+{
+    using WixToolset.Extensibility.Data;
+
+    /// <summary>
+    /// Interface for built-in optimizer.
+    /// </summary>
+    public interface IOptimizer
+    {
+        /// <summary>
+        /// Called after all files have been compiled and before all sections are linked into a single section.
+        /// </summary>
+        void Optimize(IOptimizeContext context);
+    }
+}

--- a/src/wix/WixToolset.Core/OptimizeContext.cs
+++ b/src/wix/WixToolset.Core/OptimizeContext.cs
@@ -1,0 +1,39 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading;
+    using WixToolset.Data;
+    using WixToolset.Extensibility;
+    using WixToolset.Extensibility.Data;
+
+    internal class OptimizeContext : IOptimizeContext
+    {
+        internal OptimizeContext(IServiceProvider serviceProvider)
+        {
+            this.ServiceProvider = serviceProvider;
+        }
+
+        public IServiceProvider ServiceProvider { get; }
+
+        public IReadOnlyCollection<IOptimizerExtension> Extensions { get; set; }
+
+        public string IntermediateFolder { get; set; }
+
+        public IReadOnlyCollection<IBindPath> BindPaths { get; set; }
+
+        public IDictionary<string, string> BindVariables { get; set; }
+
+        public Platform Platform { get; set; }
+
+        public bool IsCurrentPlatform64Bit => this.Platform == Platform.ARM64 || this.Platform == Platform.X64;
+
+        public IReadOnlyCollection<Intermediate> Intermediates { get; set; }
+
+        public IReadOnlyCollection<Localization> Localizations { get; set; }
+
+        public CancellationToken CancellationToken { get; set; }
+    }
+}

--- a/src/wix/WixToolset.Core/Optimizer.cs
+++ b/src/wix/WixToolset.Core/Optimizer.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core
+{
+    using System;
+    using WixToolset.Extensibility.Data;
+    using WixToolset.Extensibility.Services;
+
+    internal class Optimizer : IOptimizer
+    {
+        internal Optimizer(IServiceProvider serviceProvider)
+        {
+            this.ServiceProvider = serviceProvider;
+            this.Messaging = this.ServiceProvider.GetService<IMessaging>();
+        }
+
+        private IServiceProvider ServiceProvider { get; }
+
+        private IMessaging Messaging { get; }
+
+        public void Optimize(IOptimizeContext context)
+        {
+            foreach (var extension in context.Extensions)
+            {
+                extension.PreOptimize(context);
+            }
+
+            // TODO: Fill with useful optimization features.
+
+            foreach (var extension in context.Extensions)
+            {
+                extension.PostOptimize(context);
+            }
+        }
+    }
+}

--- a/src/wix/WixToolset.Core/WixToolsetServiceProvider.cs
+++ b/src/wix/WixToolset.Core/WixToolsetServiceProvider.cs
@@ -37,6 +37,7 @@ namespace WixToolset.Core
             this.AddService<ICommandLine>((provider, singletons) => new CommandLine.CommandLine(provider));
             this.AddService<IPreprocessContext>((provider, singletons) => new PreprocessContext(provider));
             this.AddService<ICompileContext>((provider, singletons) => new CompileContext(provider));
+            this.AddService<IOptimizeContext>((provider, singletons) => new OptimizeContext(provider));
             this.AddService<ILibraryContext>((provider, singletons) => new LibraryContext(provider));
             this.AddService<ILibraryResult>((provider, singletons) => new LibraryResult());
             this.AddService<ILinkContext>((provider, singletons) => new LinkContext(provider));
@@ -58,6 +59,7 @@ namespace WixToolset.Core
 
             this.AddService<IBinder>((provider, singletons) => new Binder(provider));
             this.AddService<ICompiler>((provider, singletons) => new Compiler(provider));
+            this.AddService<IOptimizer>((provider, singletons) => new Optimizer(provider));
             this.AddService<ILayoutCreator>((provider, singletons) => new LayoutCreator(provider));
             this.AddService<IPreprocessor>((provider, singletons) => new Preprocessor(provider));
             this.AddService<ILibrarian>((provider, singletons) => new Librarian(provider));

--- a/src/wix/test/Example.Extension/ExampleExtensionFactory.cs
+++ b/src/wix/test/Example.Extension/ExampleExtensionFactory.cs
@@ -35,6 +35,10 @@ namespace Example.Extension
             {
                 extension = new ExampleCompilerExtension();
             }
+            else if (extensionType == typeof(IOptimizerExtension))
+            {
+                extension = new ExampleOptimizerExtension();
+            }
             else if (extensionType == typeof(IExtensionData))
             {
                 extension = new ExampleExtensionData();

--- a/src/wix/test/Example.Extension/ExampleOptimizerExtension.cs
+++ b/src/wix/test/Example.Extension/ExampleOptimizerExtension.cs
@@ -1,0 +1,22 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace Example.Extension
+{
+    using System.Linq;
+    using WixToolset.Extensibility;
+    using WixToolset.Extensibility.Data;
+
+    internal class ExampleOptimizerExtension : BaseOptimizerExtension
+    {
+        public override void PostOptimize(IOptimizeContext context)
+        {
+            foreach (var intermediate in context.Intermediates)
+            {
+                foreach (var symbol in intermediate.Sections.SelectMany(s=>s.Symbols).OfType<ExampleSymbol>())
+                {
+                    symbol.Value = $"{symbol.Value} <optimized>";
+                }
+            }
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/ExtensionFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/ExtensionFixture.cs
@@ -24,7 +24,7 @@ namespace WixToolsetTest.CoreIntegration
             var results = build.BuildAndQuery(Build, "Wix4Example");
             WixAssert.CompareLineByLine(new[]
             {
-                "Wix4Example:Foo\tfilF5_pLhBuF5b4N9XEo52g_hUM5Lo\tBar"
+                "Wix4Example:Foo\tfilF5_pLhBuF5b4N9XEo52g_hUM5Lo\tBar <optimized>"
             }, results);
         }
 
@@ -92,7 +92,7 @@ namespace WixToolsetTest.CoreIntegration
                 var example = section.Symbols.Where(t => t.Definition.Type == SymbolDefinitionType.MustBeFromAnExtension).Single();
                 WixAssert.StringEqual("Foo", example.Id?.Id);
                 WixAssert.StringEqual("filF5_pLhBuF5b4N9XEo52g_hUM5Lo", example[0].AsString());
-                WixAssert.StringEqual("Bar", example[1].AsString());
+                WixAssert.StringEqual("Bar <optimized>", example[1].AsString());
             }
         }
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExampleExtension/Decompiled-Expected.xml
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/ExampleExtension/Decompiled-Expected.xml
@@ -5,7 +5,7 @@
     <StandardDirectory Id="ProgramFilesFolder">
       <Directory Id="INSTALLFOLDER" ShortName="oekcr5lq" Name="MsiPackage">
         <Component Id="filF5_pLhBuF5b4N9XEo52g_hUM5Lo" Guid="{GUID}" Bitness="always32">
-          <Example Id="Foo" Value="Bar" xmlns="http://www.example.com/scheams/v1/wxs" />
+          <Example Id="Foo" Value="Bar &lt;optimized&gt;" xmlns="http://www.example.com/scheams/v1/wxs" />
           <File Id="filF5_pLhBuF5b4N9XEo52g_hUM5Lo" Name="example.txt" KeyPath="yes" Source="PFiles\MsiPackage\example.txt" />
         </Component>
       </Directory>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/WixlibFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/WixlibFixture.cs
@@ -288,7 +288,7 @@ namespace WixToolsetTest.CoreIntegration
 
                 var example = section.Symbols.Where(t => t.Definition.Type == SymbolDefinitionType.MustBeFromAnExtension).Single();
                 WixAssert.StringEqual("Foo", example.Id?.Id);
-                WixAssert.StringEqual("Bar", example[1].AsString());
+                WixAssert.StringEqual("Bar <optimized>", example[1].AsString());
             }
         }
 
@@ -351,7 +351,7 @@ namespace WixToolsetTest.CoreIntegration
                 var examples = section.Symbols.Where(t => t.Definition.Type == SymbolDefinitionType.MustBeFromAnExtension).ToArray();
                 WixAssert.CompareLineByLine(new[] { "Foo", "Other" }, examples.Select(t => t.Id?.Id).ToArray());
                 WixAssert.CompareLineByLine(new[] { "filF5_pLhBuF5b4N9XEo52g_hUM5Lo", "filvxdStJhRE_M5kbpLsTZJXbs34Sg" }, examples.Select(t => t[0].AsString()).ToArray());
-                WixAssert.CompareLineByLine(new[] { "Bar", "Value" }, examples.Select(t => t[1].AsString()).ToArray());
+                WixAssert.CompareLineByLine(new[] { "Bar <optimized>", "Value <optimized>" }, examples.Select(t => t[1].AsString()).ToArray());
             }
         }
     }


### PR DESCRIPTION
A useful point in the build pipeline is after all the files in the project have been compiled but before they've been linked. The WiX core and extensions can operate on symbols across the project but without operating at the source-code level.

This phase is currently named "optimize," after a moderately-similar phase in other compiler architectures. The name is, for now, a stake in the ground and a better alternate is welcome.