### PR TITLE
Include duplicated inline directory symbols referenced in subsequent sections

### DIFF
--- a/src/wix/WixToolset.Core/Link/ReportConflictingSymbolsCommand.cs
+++ b/src/wix/WixToolset.Core/Link/ReportConflictingSymbolsCommand.cs
@@ -40,7 +40,9 @@ namespace WixToolset.Core.Link
 
                     if (actuallyReferencedDuplicates.Any())
                     {
-                        this.Messaging.Write(ErrorMessages.DuplicateSymbol(referencedDuplicate.Symbol.SourceLineNumbers, referencedDuplicate.Name));
+                        var fullName = referencedDuplicate.GetFullName();
+
+                        this.Messaging.Write(ErrorMessages.DuplicateSymbol(referencedDuplicate.Symbol.SourceLineNumbers, fullName));
 
                         foreach (var duplicate in actuallyReferencedDuplicates)
                         {

--- a/src/wix/WixToolset.Core/Link/ResolveReferencesCommand.cs
+++ b/src/wix/WixToolset.Core/Link/ResolveReferencesCommand.cs
@@ -91,15 +91,16 @@ namespace WixToolset.Core.Link
                     else // display errors for the duplicate symbols.
                     {
                         var accessibleSymbol = accessible[0];
+                        var accessibleFullName = accessibleSymbol.GetFullName();
                         var referencingSourceLineNumber = wixSimpleReferenceRow.SourceLineNumbers?.ToString();
 
                         if (String.IsNullOrEmpty(referencingSourceLineNumber))
                         {
-                            this.Messaging.Write(ErrorMessages.DuplicateSymbol(accessibleSymbol.Symbol.SourceLineNumbers, accessibleSymbol.Name));
+                            this.Messaging.Write(ErrorMessages.DuplicateSymbol(accessibleSymbol.Symbol.SourceLineNumbers, accessibleFullName));
                         }
                         else
                         {
-                            this.Messaging.Write(ErrorMessages.DuplicateSymbol(accessibleSymbol.Symbol.SourceLineNumbers, accessibleSymbol.Name, referencingSourceLineNumber));
+                            this.Messaging.Write(ErrorMessages.DuplicateSymbol(accessibleSymbol.Symbol.SourceLineNumbers, accessibleFullName, referencingSourceLineNumber));
                         }
 
                         foreach (var accessibleDuplicate in accessible.Skip(1))
@@ -140,14 +141,6 @@ namespace WixToolset.Core.Link
                     continue;
                 }
 
-                if (this.AccessibleSymbol(referencingSection, dupe))
-                {
-                    accessibleSymbols.Add(dupe);
-                }
-            }
-
-            foreach (var dupe in symbolWithSection.Redundants)
-            {
                 if (this.AccessibleSymbol(referencingSection, dupe))
                 {
                     accessibleSymbols.Add(dupe);

--- a/src/wix/WixToolset.Core/Link/SymbolWithSection.cs
+++ b/src/wix/WixToolset.Core/Link/SymbolWithSection.cs
@@ -13,7 +13,6 @@ namespace WixToolset.Core.Link
     internal class SymbolWithSection
     {
         private HashSet<SymbolWithSection> possibleConflicts;
-        private HashSet<SymbolWithSection> redundants;
 
         /// <summary>
         /// Creates a symbol for a symbol.
@@ -24,7 +23,6 @@ namespace WixToolset.Core.Link
         {
             this.Symbol = symbol;
             this.Section = section;
-            this.Name = String.Concat(this.Symbol.Definition.Name, ":", this.Symbol.Id.Id);
         }
 
         /// <summary>
@@ -32,12 +30,6 @@ namespace WixToolset.Core.Link
         /// </summary>
         /// <value>Accessbility of the symbol.</value>
         public AccessModifier Access => this.Symbol.Id.Access;
-
-        /// <summary>
-        /// Gets the name of the symbol.
-        /// </summary>
-        /// <value>Name of the symbol.</value>
-        public string Name { get; }
 
         /// <summary>
         /// Gets the symbol for this symbol.
@@ -57,11 +49,6 @@ namespace WixToolset.Core.Link
         public IEnumerable<SymbolWithSection> PossiblyConflicts => this.possibleConflicts ?? Enumerable.Empty<SymbolWithSection>();
 
         /// <summary>
-        /// Gets any duplicates of this symbol with sections that are redundant.
-        /// </summary>
-        public IEnumerable<SymbolWithSection> Redundants => this.redundants ?? Enumerable.Empty<SymbolWithSection>();
-
-        /// <summary>
         /// Adds a duplicate symbol with sections that is a possible conflict.
         /// </summary>
         /// <param name="symbolWithSection">Symbol with section that is a possible conflict of this symbol.</param>
@@ -76,17 +63,11 @@ namespace WixToolset.Core.Link
         }
 
         /// <summary>
-        /// Adds a duplicate symbol that is redundant.
+        /// Gets the full name of the symbol.
         /// </summary>
-        /// <param name="symbolWithSection">Symbol with section that is redundant of this symbol.</param>
-        public void AddRedundant(SymbolWithSection symbolWithSection)
+        public string GetFullName()
         {
-            if (null == this.redundants)
-            {
-                this.redundants = new HashSet<SymbolWithSection>();
-            }
-
-            this.redundants.Add(symbolWithSection);
+            return String.Concat(this.Symbol.Definition.Name, ":", this.Symbol.Id.Id);
         }
     }
 }

--- a/src/wix/WixToolset.Core/Linker.cs
+++ b/src/wix/WixToolset.Core/Linker.cs
@@ -177,14 +177,20 @@ namespace WixToolset.Core
                 // metadata.
                 var resolvedSection = new IntermediateSection(find.EntrySection.Id, find.EntrySection.Type);
                 var references = new List<WixSimpleReferenceSymbol>();
+                var identicalDirectoryIds = new HashSet<string>(StringComparer.Ordinal);
 
                 foreach (var section in sections)
                 {
                     foreach (var symbol in section.Symbols)
                     {
-                        if (find.RedundantSymbols.Contains(symbol))
+                        // If this symbol is an identical directory, ensure we only visit
+                        // one (and skip the other identicals with the same id).
+                        if (find.IdenticalDirectorySymbols.Contains(symbol))
                         {
-                            continue;
+                            if (!identicalDirectoryIds.Add(symbol.Id.Id))
+                            {
+                                continue;
+                            }
                         }
 
                         var copySymbol = true; // by default, copy symbols.
@@ -351,22 +357,24 @@ namespace WixToolset.Core
             foreach (var actionSymbol in WindowsInstallerStandard.StandardActions())
             {
                 var symbolWithSection = new SymbolWithSection(null, actionSymbol);
+                var fullName = symbolWithSection.GetFullName();
 
                 // If the action's symbol has not already been defined (i.e. overriden by the user), add it now.
-                if (!symbolsByName.ContainsKey(symbolWithSection.Name))
+                if (!symbolsByName.ContainsKey(fullName))
                 {
-                    symbolsByName.Add(symbolWithSection.Name, symbolWithSection);
+                    symbolsByName.Add(fullName, symbolWithSection);
                 }
             }
 
             foreach (var directorySymbol in WindowsInstallerStandard.StandardDirectories())
             {
                 var symbolWithSection = new SymbolWithSection(null, directorySymbol);
+                var fullName = symbolWithSection.GetFullName();
 
                 // If the directory's symbol has not already been defined (i.e. overriden by the user), add it now.
-                if (!symbolsByName.ContainsKey(symbolWithSection.Name))
+                if (!symbolsByName.ContainsKey(fullName))
                 {
-                    symbolsByName.Add(symbolWithSection.Name, symbolWithSection);
+                    symbolsByName.Add(fullName, symbolWithSection);
                 }
             }
         }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Directory/RedundantSubdirectoryInSecondSection.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/Directory/RedundantSubdirectoryInSecondSection.wxs
@@ -1,0 +1,26 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="~RedundantSubdirectories" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="12E4699F-E774-4D05-8A01-5BDD41BBA127" Compressed="no">
+        <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+
+        <Feature Id="ProductFeature">
+            <!-- NotIncludeButFirst will define the subdirectory and IncludedButSecond needs the same symbols, this tests linking order -->
+            <ComponentGroupRef Id="IncludedButSecond" />
+        </Feature>
+    </Package>
+
+    <Fragment Id="NotIncludedButFirst">
+        <ComponentGroup Id="NotIncludedButFirst">
+            <Component Directory="ProgramFilesFolder" Subdirectory="a\b\c">
+                <File Name="notincluded.txt" Source="test.txt" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+
+    <Fragment Id="IncludedButSecond">
+        <ComponentGroup Id="IncludedButSecond">
+            <Component Directory="ProgramFilesFolder" Subdirectory="a\b\c">
+                <File Name="included.txt" Source="test.txt" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>


### PR DESCRIPTION
Due to the handling of redundant symbols, which are only used by inline directory syntax, the symbols were only defined in the first section encountered by the linker. Fix that so at most one duplicated inline directory symbol is included when referenced.

Fixes wixtoolset/issues#7840