### PR TITLE
ArpEntry reads QuietUninstallString or UninstallString, and uses UninstallArguments for the uninstall command line

### DIFF
--- a/src/api/wix/WixToolset.Data/Symbols/WixBundleExePackageSymbol.cs
+++ b/src/api/wix/WixToolset.Data/Symbols/WixBundleExePackageSymbol.cs
@@ -57,6 +57,7 @@ namespace WixToolset.Data.Symbols
         None = 0,
         Bundle = 1,
         ArpWin64 = 2,
+        ArpUseUninstallString = 4,
     }
 
     public class WixBundleExePackageSymbol : IntermediateSymbol
@@ -153,6 +154,22 @@ namespace WixToolset.Data.Symbols
                 else
                 {
                     this.Attributes &= ~WixBundleExePackageAttributes.ArpWin64;
+                }
+            }
+        }
+
+        public bool ArpUseUninstallString
+        {
+            get { return this.Attributes.HasFlag(WixBundleExePackageAttributes.ArpUseUninstallString); }
+            set
+            {
+                if (value)
+                {
+                    this.Attributes |= WixBundleExePackageAttributes.ArpUseUninstallString;
+                }
+                else
+                {
+                    this.Attributes &= ~WixBundleExePackageAttributes.ArpUseUninstallString;
                 }
             }
         }

--- a/src/burn/engine/exeengine.cpp
+++ b/src/burn/engine/exeengine.cpp
@@ -81,6 +81,14 @@ extern "C" HRESULT ExeEngineParsePackageFromXml(
         hr = XmlGetYesNoAttribute(pixnExePackage, L"ArpWin64", &pPackage->Exe.fArpWin64);
         ExitOnOptionalXmlQueryFailure(hr, fFoundXml, "Failed to get @ArpWin64.");
 
+        // @ArpUseUninstallString
+        hr = XmlGetYesNoAttribute(pixnExePackage, L"ArpUseUninstallString", &pPackage->Exe.fArpUseUninstallString);
+        ExitOnOptionalXmlQueryFailure(hr, fFoundXml, "Failed to get @ArpWin64.");
+
+        // @UninstallArguments
+        hr = XmlGetAttributeEx(pixnExePackage, L"UninstallArguments", &pPackage->Exe.sczUninstallArguments);
+        ExitOnOptionalXmlQueryFailure(hr, fFoundXml, "Failed to get @UninstallArguments.");
+
         pPackage->Exe.fUninstallable = TRUE;
     }
 
@@ -481,7 +489,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
     }
     else if (BURN_EXE_DETECTION_TYPE_ARP == pPackage->Exe.detectionType && BOOTSTRAPPER_ACTION_STATE_UNINSTALL == pExecuteAction->exePackage.action)
     {
-        ExitOnNull(sczArpUninstallString, hr, E_INVALIDARG, "QuietUninstallString is null.");
+        ExitOnNull(sczArpUninstallString, hr, E_INVALIDARG, "%hs is null.", pPackage->Exe.fArpUseUninstallString ? "UninstallString" : "QuietUninstallString");
 
         hr = AppParseCommandLine(sczArpUninstallString, &argcArp, &argvArp);
         ExitOnFailure(hr, "Failed to parse QuietUninstallString: %ls.", sczArpUninstallString);
@@ -1122,8 +1130,20 @@ static HRESULT DetectArpEntry(
 
     if (psczQuietUninstallString)
     {
-        hr = RegReadString(hKey, L"QuietUninstallString", psczQuietUninstallString);
-        ExitOnPathFailure(hr, fExists, "Failed to read QuietUninstallString.");
+        LPCWSTR sczUninstallStringName = pPackage->Exe.fArpUseUninstallString ? L"UninstallString" : L"QuietUninstallString";
+
+        hr = RegReadString(hKey, sczUninstallStringName, psczQuietUninstallString);
+        ExitOnPathFailure(hr, fExists, "Failed to read %ls.", sczUninstallStringName);
+
+        // If the uninstall string is an executable path then ensure it is enclosed in quotes
+        if (fExists && *psczQuietUninstallString && (L'\"' != **psczQuietUninstallString) && FileExistsEx(*psczQuietUninstallString, nullptr))
+        {
+            hr = StrAllocPrefix(psczQuietUninstallString, L"\"", 0);
+            ExitOnFailure(hr, "Failed to prepend UninstallString with quote.");
+
+            hr = StrAllocConcat(psczQuietUninstallString, L"\"", 0);
+            ExitOnFailure(hr, "Failed to append quote to UninstallString.");
+        }
     }
 
 LExit:

--- a/src/burn/engine/package.h
+++ b/src/burn/engine/package.h
@@ -362,6 +362,7 @@ typedef struct _BURN_PACKAGE
             BURN_EXE_DETECTION_TYPE detectionType;
 
             BOOL fArpWin64;
+            BOOL fArpUseUninstallString;
             LPWSTR sczArpKeyPath;
             VERUTIL_VERSION* pArpDisplayVersion;
 

--- a/src/test/burn/TestData/ExePackageTests/PerMachineArpEntryWithUninstallStringExePackage/PerMachineArpEntryWithUninstallStringExePackage.wixproj
+++ b/src/test/burn/TestData/ExePackageTests/PerMachineArpEntryWithUninstallStringExePackage/PerMachineArpEntryWithUninstallStringExePackage.wixproj
@@ -1,0 +1,19 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<Project Sdk="WixToolset.Sdk">
+  <PropertyGroup>
+    <OutputType>Bundle</OutputType>
+    <InstallerPlatform>x64</InstallerPlatform>
+    <BA>TestBA_x64</BA>
+    <UpgradeCode>{0A3D66F0-21A8-41B5-BE9A-7A9ABDEC3AB5}</UpgradeCode>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Templates\Bundle.wxs" Link="Bundle.wxs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\TestBA\TestBAWixlib_x64\testbawixlib_x64.wixproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Bal.wixext" />
+    <PackageReference Include="WixToolset.NetFx.wixext" />
+  </ItemGroup>
+</Project>

--- a/src/test/burn/TestData/ExePackageTests/PerMachineArpEntryWithUninstallStringExePackage/PerMachineArpEntryWithUninstallStringExePackage.wxs
+++ b/src/test/burn/TestData/ExePackageTests/PerMachineArpEntryWithUninstallStringExePackage/PerMachineArpEntryWithUninstallStringExePackage.wxs
@@ -1,0 +1,18 @@
+﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<?define ArpId = {21E99C0F-E604-439C-97E0-33B9771394BC}?>
+<?define ArpKeyPath = HKLM\SOFTWARE\Microsoft\Windows\CurrentVersion\Uninstall\$(var.ArpId)?>
+<?define ArpVersion = 1.0.0.0?>
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <PackageGroup Id="BundlePackages">
+      <ExePackage Id="TestExe" PerMachine="yes"
+                  InstallArguments="/regw &quot;$(var.ArpKeyPath),DisplayVersion,String,$(var.ArpVersion)&quot; /regw &quot;$(var.ArpKeyPath),UninstallString,String,\&quot;[WixBundleExecutePackageCacheFolder]testexe.exe\&quot; /regd \&quot;$(var.ArpKeyPath)\&quot;&quot;">
+        <ArpEntry Id="$(var.ArpId)" Version="$(var.ArpVersion)" Win64="yes" UseUninstallString="yes" />
+
+        <PayloadGroupRef Id="TestExePayloads_x64" />
+      </ExePackage>
+    </PackageGroup>
+  </Fragment>
+</Wix>

--- a/src/wix/WixToolset.Core.Burn/Bundles/CreateBurnManifestCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/CreateBurnManifestCommand.cs
@@ -436,6 +436,16 @@ namespace WixToolset.Core.Burn.Bundles
                                 {
                                     writer.WriteAttributeString("ArpWin64", "yes");
                                 }
+
+                                if (exePackage.ArpUseUninstallString)
+                                {
+                                    writer.WriteAttributeString("ArpUseUninstallString", "yes");
+                                }
+
+                                if (!String.IsNullOrEmpty(exePackage.UninstallCommand))
+                                {
+                                    writer.WriteAttributeString("UninstallArguments", exePackage.UninstallCommand);
+                                }
                                 break;
                             case WixBundleExePackageDetectionType.None:
                                 writer.WriteAttributeString("DetectionType", "none");


### PR DESCRIPTION
Fixes wixtoolset/issues#7877