### PR TITLE
Rename IWindowsInstallerDecompileContext...

### DIFF
--- a/src/api/wix/WixToolset.Extensibility/Data/IWindowsInstallerDecompileContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/IWindowsInstallerDecompileContext.cs
@@ -96,6 +96,6 @@ namespace WixToolset.Extensibility.Data
         /// Gets or sets whether the decompiler should keep modularization
         /// GUIDs (true) or remove them (default/false).
         /// </summary>
-        bool TreatProductAsModule { get; set; }
+        bool KeepModularizationIds { get; set; }
     }
 }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Decompile/Decompiler.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Decompile/Decompiler.cs
@@ -43,7 +43,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
         /// <summary>
         /// Creates a new decompiler object with a default set of table definitions.
         /// </summary>
-        public Decompiler(IMessaging messaging, IBackendHelper backendHelper, IWindowsInstallerDecompilerHelper decompilerHelper, IEnumerable<IWindowsInstallerDecompilerExtension> extensions, IEnumerable<IExtensionData> extensionData, ISymbolDefinitionCreator creator, string baseSourcePath, bool suppressCustomTables, bool suppressDroppingEmptyTables, bool suppressRelativeActionSequencing, bool suppressUI, bool treatProductAsModule)
+        public Decompiler(IMessaging messaging, IBackendHelper backendHelper, IWindowsInstallerDecompilerHelper decompilerHelper, IEnumerable<IWindowsInstallerDecompilerExtension> extensions, IEnumerable<IExtensionData> extensionData, ISymbolDefinitionCreator creator, string baseSourcePath, bool suppressCustomTables, bool suppressDroppingEmptyTables, bool suppressRelativeActionSequencing, bool suppressUI, bool keepModularizationIds)
         {
             this.Messaging = messaging;
             this.BackendHelper = backendHelper;
@@ -56,7 +56,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
             this.SuppressDroppingEmptyTables = suppressDroppingEmptyTables;
             this.SuppressRelativeActionSequencing = suppressRelativeActionSequencing;
             this.SuppressUI = suppressUI;
-            this.TreatProductAsModule = treatProductAsModule;
+            this.KeepModularizationIds = keepModularizationIds;
 
             this.ExtensionsByTableName = new Dictionary<string, IWindowsInstallerDecompilerExtension>();
             this.StandardActions = WindowsInstallerStandard.StandardActions().ToDictionary(a => a.Id.Id);
@@ -88,7 +88,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
 
         private bool SuppressUI { get; }
 
-        private bool TreatProductAsModule { get; }
+        private bool KeepModularizationIds { get; }
 
         private OutputType OutputType { get; set; }
 
@@ -1188,7 +1188,7 @@ namespace WixToolset.Core.WindowsInstaller.Decompile
                     var fileName = xFile?.Attribute("Name")?.Value;
 
                     // set the source (done here because it requires information from the Directory table)
-                    if (OutputType.Module == this.OutputType && !this.TreatProductAsModule)
+                    if (OutputType.Module == this.OutputType && !this.KeepModularizationIds)
                     {
                         xFile.SetAttributeValue("Source", String.Concat(this.BaseSourcePath, Path.DirectorySeparatorChar, "File", Path.DirectorySeparatorChar, fileId, '.', this.ModularizationGuid.Substring(1, 36).Replace('-', '_')));
                     }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Melter.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Melter.cs
@@ -85,7 +85,7 @@ namespace WixToolset
             PreDecompile(wixout);
 
             wixout.Type = OutputType.Package;
-            this.decompiler.TreatProductAsModule = true;
+            this.decompiler.KeepModularizationIds = true;
             Wix.Wix wix = this.decompiler.Decompile(wixout);
 
             if (null == wix)

--- a/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerDecompileContext.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerDecompileContext.cs
@@ -49,6 +49,6 @@ namespace WixToolset.Core.WindowsInstaller
 
         public bool SuppressUI { get; set; }
 
-        public bool TreatProductAsModule { get; set; }
+        public bool KeepModularizationIds { get; set; }
     }
 }

--- a/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerDecompiler.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/WindowsInstallerDecompiler.cs
@@ -94,21 +94,13 @@ namespace WixToolset.Core.WindowsInstaller
             var extractFilesFolder = context.SuppressExtractCabinets || (String.IsNullOrEmpty(context.CabinetExtractFolder) && String.IsNullOrEmpty(context.ExtractFolder)) ? null :
                 String.IsNullOrEmpty(context.CabinetExtractFolder) ? Path.Combine(context.ExtractFolder, "File") : context.CabinetExtractFolder;
 
-            // IWindowsInstallerDecompileContext.TreatProductAsModule is broken. So broken, in fact,
-            // that it's been broken since WiX v3.0 in 2008. It was introduced (according to lore)
-            // to support Melt, which decompiles merge modules into fragments so you can consume
-            // merge modules without actually going through the black box that is mergemod.dll. But
-            // the name is wrong: It's not TreatProductAsModule; if anything it should instead be
-            // TreatModuleAsProduct, though even that's wrong (because you want a fragment, not a
-            // product/package). In WiX v5, rename to `KeepModularizeIds` (or something better) to
-            // reflect the functionality.
-            var demodularize = !context.TreatProductAsModule;
+            var demodularize = !context.KeepModularizationIds;
             var sectionType = context.DecompileType;
             var unbindCommand = new UnbindDatabaseCommand(this.Messaging, backendHelper, fileSystem, pathResolver, context.DecompilePath, null, sectionType, context.ExtractFolder, extractFilesFolder, context.IntermediateFolder, demodularize, skipSummaryInfo: false);
             var output = unbindCommand.Execute();
             var extractedFilePaths = unbindCommand.ExportedFiles;
 
-            var decompiler = new Decompiler(this.Messaging, backendHelper, decompilerHelper, context.Extensions, context.ExtensionData, context.SymbolDefinitionCreator, context.BaseSourcePath, context.SuppressCustomTables, context.SuppressDroppingEmptyTables, context.SuppressRelativeActionSequencing, context.SuppressUI, context.TreatProductAsModule);
+            var decompiler = new Decompiler(this.Messaging, backendHelper, decompilerHelper, context.Extensions, context.ExtensionData, context.SymbolDefinitionCreator, context.BaseSourcePath, context.SuppressCustomTables, context.SuppressDroppingEmptyTables, context.SuppressRelativeActionSequencing, context.SuppressUI, context.KeepModularizationIds);
             var document = decompiler.Decompile(output);
 
             var result = context.ServiceProvider.GetService<IWindowsInstallerDecompileResult>();

--- a/src/wix/test/WixToolsetTest.CoreIntegration/DecompileFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/DecompileFixture.cs
@@ -108,7 +108,7 @@ namespace WixToolsetTest.CoreIntegration
         }
 
         [Fact]
-        public void CanDecompileMergeModuleWithTreatProductAsModule()
+        public void CanDecompileMergeModuleWithKeepModularizationIds()
         {
             using (var fs = new DisposableFileSystem())
             {
@@ -127,7 +127,7 @@ namespace WixToolsetTest.CoreIntegration
                 context.ExtensionData = extensionManager.GetServices<IExtensionData>();
                 context.DecompilePath = Path.Combine(sourceFolder, "MergeModule1.msm");
                 context.DecompileType = OutputType.Module;
-                context.TreatProductAsModule = true;
+                context.KeepModularizationIds = true;
                 context.IntermediateFolder = intermediateFolder;
                 context.ExtractFolder = outputFolder;
                 context.CabinetExtractFolder = outputFolder;


### PR DESCRIPTION
...TreatProductAsModule to KeepModularizationIds to better describe what it does.

Fixes https://github.com/wixtoolset/issues/issues/7607.