### PR TITLE
Use `/DEPENDENTLOADFLAG` to tell the loader...

### DIFF
--- a/src/burn/stub/stub.vcxproj
+++ b/src/burn/stub/stub.vcxproj
@@ -63,6 +63,7 @@
       <SwapRunFromCD>true</SwapRunFromCD>
       <SwapRunFromNET>true</SwapRunFromNET>
       <DelayLoadDLLs>cabinet.dll;crypt32.dll;msi.dll;shlwapi.dll;userenv.dll;version.dll;wininet.dll;wintrust.dll</DelayLoadDLLs>
+      <AdditionalOptions>/DEPENDENTLOADFLAG:0x800 %(AdditionalOptions)</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
 


### PR DESCRIPTION
...to load DLLs from System32 only.

(Belt and suspenders to current approaches.) See
https://devblogs.microsoft.com/oldnewthing/20230328-00/?p=107978.

Fixes https://github.com/wixtoolset/issues/issues/7319.