### PR TITLE
Fix crash when CloseApplications_X64 closes Electron app

### DIFF
--- a/src/libs/dutil/WixToolset.DUtil/procutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/procutil.cpp
@@ -517,7 +517,7 @@ extern "C" HRESULT DAPI ProcWaitForIds(
     DWORD cProcesses = 0;
     BOOL fTimedOut = FALSE;
 
-    rghProcesses =  static_cast<HANDLE*>(MemAlloc(sizeof(DWORD) * cProcessIds, TRUE));
+    rghProcesses =  static_cast<HANDLE*>(MemAlloc(sizeof(HANDLE) * cProcessIds, TRUE));
     ProcExitOnNull(rgdwProcessIds, hr, E_OUTOFMEMORY, "Failed to allocate array for process ID Handles.");
 
     for (DWORD i = 0; i < cProcessIds; ++i)


### PR DESCRIPTION
CloseApplications custom action may crash on 64-bit systems if the number of processes to close exceeds the default memory alignment for a platform. E.g. on AMD64 seven processes is enough to trigger the problem, while on ARM64 it has to be more.

I encountered the above problem trying to close an Electron application. Electron apps have at least 6 child processes of the very same name as the master process. It causes a buffer overflow in `ProcWaitForIds` function.
