### PR TITLE
Add `Files` file harvesting.

### DIFF
--- a/src/api/wix/WixToolset.Data/ErrorMessages.cs
+++ b/src/api/wix/WixToolset.Data/ErrorMessages.cs
@@ -368,6 +368,11 @@ namespace WixToolset.Data
             return Message(sourceLineNumbers, Ids.ExpectedAttribute, "The {0}/@{1} attribute was not found; it is required unless the attribute {2} has a value of '{3}'.", elementName, attributeName, otherAttributeName, otherAttributeValue, otherAttributeValueUnless);
         }
 
+        public static Message ExpectedAttributeInElementOrParent(SourceLineNumber sourceLineNumbers, string elementName, string attributeName)
+        {
+            return Message(sourceLineNumbers, Ids.ExpectedAttributeInElementOrParent, "The {0}/@{1} attribute was not found or empty; it is required unless it is specified in the parent element.", elementName, attributeName);
+        }
+
         public static Message ExpectedAttributeInElementOrParent(SourceLineNumber sourceLineNumbers, string elementName, string attributeName, string parentElementName)
         {
             return Message(sourceLineNumbers, Ids.ExpectedAttributeInElementOrParent, "The {0}/@{1} attribute was not found or empty; it is required, or it can be specified in the parent {2} element.", elementName, attributeName, parentElementName);

--- a/src/api/wix/WixToolset.Data/Symbols/HarvestFilesSymbol.cs
+++ b/src/api/wix/WixToolset.Data/Symbols/HarvestFilesSymbol.cs
@@ -1,0 +1,84 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Data
+{
+    using WixToolset.Data.Symbols;
+
+    public static partial class SymbolDefinitions
+    {
+        public static readonly IntermediateSymbolDefinition HarvestFiles = new IntermediateSymbolDefinition(
+            SymbolDefinitionType.HarvestFiles,
+            new[]
+            {
+                new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.DirectoryRef), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.Inclusions), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.Exclusions), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.ComplexReferenceParentType), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.ParentId), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.SourcePath), IntermediateFieldType.String),
+            },
+            typeof(HarvestFilesSymbol));
+    }
+}
+
+namespace WixToolset.Data.Symbols
+{
+    public enum HarvestFilesSymbolFields
+    {
+        DirectoryRef,
+        Inclusions,
+        Exclusions,
+        ComplexReferenceParentType,
+        ParentId,
+        SourcePath,
+    }
+
+    public class HarvestFilesSymbol : IntermediateSymbol
+    {
+        public HarvestFilesSymbol() : base(SymbolDefinitions.HarvestFiles, null, null)
+        {
+        }
+
+        public HarvestFilesSymbol(SourceLineNumber sourceLineNumber, Identifier id = null) : base(SymbolDefinitions.HarvestFiles, sourceLineNumber, id)
+        {
+        }
+
+        public IntermediateField this[HarvestFilesSymbolFields index] => this.Fields[(int)index];
+
+        public string DirectoryRef
+        {
+            get => (string)this.Fields[(int)HarvestFilesSymbolFields.DirectoryRef];
+            set => this.Set((int)HarvestFilesSymbolFields.DirectoryRef, value);
+        }
+
+        public string Inclusions
+        {
+            get => (string)this.Fields[(int)HarvestFilesSymbolFields.Inclusions];
+            set => this.Set((int)HarvestFilesSymbolFields.Inclusions, value);
+        }
+
+        public string Exclusions
+        {
+            get => (string)this.Fields[(int)HarvestFilesSymbolFields.Exclusions];
+            set => this.Set((int)HarvestFilesSymbolFields.Exclusions, value);
+        }
+
+        public string ComplexReferenceParentType
+        {
+            get => (string)this.Fields[(int)HarvestFilesSymbolFields.ComplexReferenceParentType];
+            set => this.Set((int)HarvestFilesSymbolFields.ComplexReferenceParentType, value);
+        }
+
+        public string ParentId
+        {
+            get => (string)this.Fields[(int)HarvestFilesSymbolFields.ParentId];
+            set => this.Set((int)HarvestFilesSymbolFields.ParentId, value);
+        }
+
+        public string SourcePath
+        {
+            get => (string)this.Fields[(int)HarvestFilesSymbolFields.SourcePath];
+            set => this.Set((int)HarvestFilesSymbolFields.SourcePath, value);
+        }
+    }
+}

--- a/src/api/wix/WixToolset.Data/Symbols/SymbolDefinitions.cs
+++ b/src/api/wix/WixToolset.Data/Symbols/SymbolDefinitions.cs
@@ -40,6 +40,7 @@ namespace WixToolset.Data
         FeatureComponents,
         File,
         FileSFPCatalog,
+        HarvestFiles,
         Icon,
         ImageFamilies,
         IniFile,

--- a/src/api/wix/WixToolset.Extensibility/Services/IParseHelper.cs
+++ b/src/api/wix/WixToolset.Extensibility/Services/IParseHelper.cs
@@ -11,7 +11,7 @@ namespace WixToolset.Extensibility.Services
     using WixToolset.Extensibility.Data;
 
     /// <summary>
-    /// Interface provided to help compiler extensions parse.
+    /// Interface provided to help compiler and optimizer extensions parse.
     /// </summary>
     public interface IParseHelper
     {

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
@@ -234,6 +234,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                         break;
 
                     // Symbols used internally and are not added to the output.
+                    case SymbolDefinitionType.HarvestFiles:
                     case SymbolDefinitionType.WixBuildInfo:
                     case SymbolDefinitionType.WixBindUpdatedFiles:
                     case SymbolDefinitionType.WixComponentGroup:

--- a/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -125,12 +125,8 @@ namespace WixToolset.Core.CommandLine
             {
                 using (new IntermediateFieldContext("wix.link"))
                 {
-                    var wixipl = inputsOutputs.Wixipls.SingleOrDefault();
-
-                    if (wixipl == null)
-                    {
-                        wixipl = this.LinkPhase(wixobjs, inputsOutputs, creator, cancellationToken);
-                    }
+                    var wixipl = inputsOutputs.Wixipls.SingleOrDefault()
+                        ?? this.LinkPhase(wixobjs, inputsOutputs, creator, cancellationToken);
 
                     if (!this.Messaging.EncounteredError)
                     {

--- a/src/wix/WixToolset.Core/Compiler_Module.cs
+++ b/src/wix/WixToolset.Core/Compiler_Module.cs
@@ -178,6 +178,9 @@ namespace WixToolset.Core
                         case "File":
                             this.ParseNakedFileElement(child, ComplexReferenceParentType.Module, this.activeName, null, null);
                             break;
+                        case "Files":
+                            this.ParseFilesElement(child, ComplexReferenceParentType.Module, this.activeName, null, null);
+                            break;
                         case "Icon":
                             this.ParseIconElement(child);
                             break;

--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -306,6 +306,9 @@ namespace WixToolset.Core
                         case "File":
                             this.ParseNakedFileElement(child, ComplexReferenceParentType.Product, productCode, null, null);
                             break;
+                        case "Files":
+                            this.ParseFilesElement(child, ComplexReferenceParentType.Unknown, null, null, null);
+                            break;
                         case "Icon":
                             this.ParseIconElement(child);
                             break;

--- a/src/wix/WixToolset.Core/HarvestFilesCommand.cs
+++ b/src/wix/WixToolset.Core/HarvestFilesCommand.cs
@@ -1,0 +1,248 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core
+{
+    using System;
+    using System.Collections.Generic;
+    using System.IO;
+    using System.Linq;
+    using WixToolset.Data;
+    using WixToolset.Data.Symbols;
+    using WixToolset.Extensibility.Data;
+    using WixToolset.Extensibility.Services;
+
+    internal class HarvestFilesCommand
+    {
+        private const string BindPathOpenString = "!(bindpath.";
+
+        public HarvestFilesCommand(IOptimizeContext context)
+        {
+            this.Context = context;
+            this.Messaging = this.Context.ServiceProvider.GetService<IMessaging>();
+            this.ParseHelper = this.Context.ServiceProvider.GetService<IParseHelper>();
+        }
+
+        public IOptimizeContext Context { get; }
+
+        public IMessaging Messaging { get; }
+
+        public IParseHelper ParseHelper { get; }
+
+        internal void Execute()
+        {
+            var harvestedFiles = new HashSet<string>();
+
+            foreach (var section in this.Context.Intermediates.SelectMany(i => i.Sections))
+            {
+                foreach (var harvestFiles in section.Symbols.OfType<HarvestFilesSymbol>().ToList())
+                {
+                    this.HarvestFiles(harvestFiles, section, harvestedFiles);
+                }
+            }
+        }
+
+        private void HarvestFiles(HarvestFilesSymbol harvestFile, IntermediateSection section, ISet<string> harvestedFiles)
+        {
+            var unusedSectionCachedInlinedDirectoryIds = new Dictionary<string, string>();
+
+            var directoryId = harvestFile.DirectoryRef;
+
+            var inclusions = harvestFile.Inclusions.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+            var exclusions = harvestFile.Exclusions.Split(new[] { ';' }, StringSplitOptions.RemoveEmptyEntries);
+
+            var comparer = new WildcardFileComparer();
+
+            var resolvedFiles = Enumerable.Empty<WildcardFile>();
+
+            try
+            {
+                var included = this.GetWildcardFiles(harvestFile, inclusions);
+                var excluded = this.GetWildcardFiles(harvestFile, exclusions);
+
+                resolvedFiles = included.Except(excluded, comparer).ToList();
+
+                if (!resolvedFiles.Any())
+                {
+                    this.Messaging.Write(OptimizerWarnings.ZeroFilesHarvested(harvestFile.SourceLineNumbers));
+                }
+            }
+            catch (DirectoryNotFoundException e)
+            {
+                this.Messaging.Write(OptimizerWarnings.ExpectedDirectory(harvestFile.SourceLineNumbers, e.Message));
+
+                return;
+            }
+
+            foreach (var fileByRecursiveDir in resolvedFiles.GroupBy(resolvedFile => resolvedFile.RecursiveDir, resolvedFile => resolvedFile.Path))
+            {
+                var recursiveDir = fileByRecursiveDir.Key;
+
+                if (!String.IsNullOrEmpty(recursiveDir))
+                {
+                    directoryId = this.ParseHelper.CreateDirectoryReferenceFromInlineSyntax(section, harvestFile.SourceLineNumbers, attribute: null, directoryId, recursiveDir, unusedSectionCachedInlinedDirectoryIds);
+                }
+
+                foreach (var file in fileByRecursiveDir)
+                {
+                    if (harvestedFiles.Add(file))
+                    {
+                        var name = Path.GetFileName(file);
+
+                        var id = this.ParseHelper.CreateIdentifier("fls", directoryId, name);
+
+                        section.AddSymbol(new FileSymbol(harvestFile.SourceLineNumbers, id)
+                        {
+                            ComponentRef = id.Id,
+                            Name = name,
+                            Attributes = FileSymbolAttributes.None | FileSymbolAttributes.Vital,
+                            DirectoryRef = directoryId,
+                            Source = new IntermediateFieldPathValue { Path = file },
+                        });
+
+                        section.AddSymbol(new ComponentSymbol(harvestFile.SourceLineNumbers, id)
+                        {
+                            ComponentId = "*",
+                            DirectoryRef = directoryId,
+                            Location = ComponentLocation.LocalOnly,
+                            KeyPath = id.Id,
+                            KeyPathType = ComponentKeyPathType.File,
+                            Win64 = this.Context.Platform == Platform.ARM64 || this.Context.Platform == Platform.X64,
+                        });
+
+                        if (Enum.TryParse<ComplexReferenceParentType>(harvestFile.ComplexReferenceParentType, out var parentType)
+                            && ComplexReferenceParentType.Unknown != parentType && null != harvestFile.ParentId)
+                        {
+                            // If the parent was provided, add a complex reference to that, and, if 
+                            // the Files is under a feature, then mark the complex reference primary.
+                            this.ParseHelper.CreateComplexReference(section, harvestFile.SourceLineNumbers, parentType, harvestFile.ParentId, null, ComplexReferenceChildType.Component, id.Id, ComplexReferenceParentType.Feature == parentType);
+                        }
+                    }
+                    else
+                    {
+                        this.Messaging.Write(OptimizerWarnings.SkippingDuplicateFile(harvestFile.SourceLineNumbers, file));
+                    }
+                }
+            }
+        }
+
+        private IEnumerable<WildcardFile> GetWildcardFiles(HarvestFilesSymbol harvestFile, IEnumerable<string> patterns)
+        {
+            var sourceLineNumbers = harvestFile.SourceLineNumbers;
+            var sourcePath = harvestFile.SourcePath;
+
+            var files = new List<WildcardFile>();
+
+            foreach (var pattern in patterns)
+            {
+                // Resolve bind paths, if any, which might result in multiple directories.
+                foreach (var path in this.ResolveBindPaths(sourceLineNumbers, pattern))
+                {
+                    var sourceDirectory = String.IsNullOrEmpty(sourcePath) ? Path.GetDirectoryName(sourceLineNumbers.FileName) : sourcePath;
+                    var recursive = path.IndexOf("**") >= 0;
+                    var filePortion = Path.GetFileName(path);
+                    var directoryPortion = Path.GetDirectoryName(path);
+
+                    if (directoryPortion?.EndsWith(@"\**") == true)
+                    {
+                        directoryPortion = directoryPortion.Substring(0, directoryPortion.Length - 3);
+                    }
+
+                    var recursiveDirOffset = directoryPortion.Length + 1;
+
+                    if (directoryPortion is null || directoryPortion.Length == 0 || directoryPortion == "**")
+                    {
+                        directoryPortion = sourceDirectory;
+                        recursiveDirOffset = sourceDirectory.Length + 1;
+
+                    }
+                    else if (!Path.IsPathRooted(directoryPortion))
+                    {
+                        directoryPortion = Path.Combine(sourceDirectory, directoryPortion);
+                        recursiveDirOffset = sourceDirectory.Length + 1;
+                    }
+
+                    var foundFiles = Directory.EnumerateFiles(directoryPortion, filePortion, recursive ? SearchOption.AllDirectories : SearchOption.TopDirectoryOnly);
+
+                    foreach (var foundFile in foundFiles)
+                    {
+                        var recursiveDir = Path.GetDirectoryName(foundFile.Substring(recursiveDirOffset));
+                        files.Add(new WildcardFile()
+                        {
+                            RecursiveDir = recursiveDir,
+                            Path = foundFile,
+                        });
+                    }
+                }
+            }
+
+            return files;
+        }
+
+        private IEnumerable<string> ResolveBindPaths(SourceLineNumber sourceLineNumbers, string source)
+        {
+            var resultingDirectories = new List<string>();
+
+            var bindName = String.Empty;
+            var path = source;
+
+            if (source.StartsWith(BindPathOpenString, StringComparison.Ordinal))
+            {
+                var closeParen = source.IndexOf(')', BindPathOpenString.Length);
+
+                if (-1 != closeParen)
+                {
+                    bindName = source.Substring(BindPathOpenString.Length, closeParen - BindPathOpenString.Length);
+                    path = source.Substring(BindPathOpenString.Length + bindName.Length + 1); // +1 for the closing brace.
+                    path = path.TrimStart('\\'); // remove starting '\\' char so the path doesn't look rooted.
+                }
+            }
+
+            if (String.IsNullOrEmpty(bindName))
+            {
+                resultingDirectories.Add(path);
+            }
+            else
+            {
+                var foundBindPath = false;
+
+                foreach (var bindPath in this.Context.BindPaths)
+                {
+                    if (bindName.Equals(bindPath.Name, StringComparison.OrdinalIgnoreCase))
+                    {
+                        var resolved = Path.Combine(bindPath.Path, path);
+                        resultingDirectories.Add(resolved);
+
+                        foundBindPath = true;
+                    }
+                }
+
+                if (!foundBindPath)
+                {
+                    this.Messaging.Write(OptimizerWarnings.ExpectedDirectory(sourceLineNumbers, source));
+                }
+            }
+
+            return resultingDirectories;
+        }
+
+        private class WildcardFile
+        {
+            public string RecursiveDir { get; set; }
+
+            public string Path { get; set; }
+        }
+
+        private class WildcardFileComparer : IEqualityComparer<WildcardFile>
+        {
+            public bool Equals(WildcardFile x, WildcardFile y)
+            {
+                return x?.Path == y?.Path;
+            }
+
+            public int GetHashCode(WildcardFile obj)
+            {
+                return obj?.Path?.GetHashCode() ?? 0;
+            }
+        }
+    }
+}

--- a/src/wix/WixToolset.Core/Optimizer.cs
+++ b/src/wix/WixToolset.Core/Optimizer.cs
@@ -25,7 +25,10 @@ namespace WixToolset.Core
                 extension.PreOptimize(context);
             }
 
-            // TODO: Fill with useful optimization features.
+            {
+                var command = new HarvestFilesCommand(context);
+                command.Execute();
+            }
 
             foreach (var extension in context.Extensions)
             {

--- a/src/wix/WixToolset.Core/OptimizerWarnings.cs
+++ b/src/wix/WixToolset.Core/OptimizerWarnings.cs
@@ -1,0 +1,36 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolset.Core
+{
+    using WixToolset.Data;
+
+    internal static class OptimizerWarnings
+    {
+        public static Message ZeroFilesHarvested(SourceLineNumber sourceLineNumbers)
+        {
+            return Message(sourceLineNumbers, Ids.ZeroFilesHarvested, "Files inclusions and exclusions resulted in zero files harvested. Unless that is expected, you should verify your Files paths, inclusions, and exclusions for accuracy.");
+        }
+
+        public static Message ExpectedDirectory(SourceLineNumber sourceLineNumbers, string harvestDirectory)
+        {
+            return Message(sourceLineNumbers, Ids.ExpectedDirectory, "Missing directory for harvesting files: {0}", harvestDirectory);
+        }
+
+        public static Message SkippingDuplicateFile(SourceLineNumber sourceLineNumbers, string duplicateFile)
+        {
+            return Message(sourceLineNumbers, Ids.SkippingDuplicateFile, "Skipping file that has already been harvested: {0}", duplicateFile);
+        }
+
+        private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
+        {
+            return new Message(sourceLineNumber, MessageLevel.Warning, (int)id, format, args);
+        }
+
+        public enum Ids
+        {
+            ZeroFilesHarvested = 8600,
+            ExpectedDirectory = 8601,
+            SkippingDuplicateFile = 8602,
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/HarvestFilesFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/HarvestFilesFixture.cs
@@ -1,0 +1,320 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.Data;
+    using System.IO;
+    using System.Linq;
+    using WixInternal.Core.TestPackage;
+    using WixInternal.TestSupport;
+    using Xunit;
+
+    public class HarvestFilesFixture
+    {
+        [Fact]
+        public void MustIncludeSomeFiles()
+        {
+            var messages = BuildAndQueryComponentAndFileTables("BadAuthoring.wxs", isPackage: true, 10);
+            Assert.Equal(new[]
+            {
+                "10",
+            }, messages);
+        }
+
+        [Fact]
+        public void ZeroFilesHarvestedIsAWarning()
+        {
+            var messages = BuildAndQueryComponentAndFileTables("ZeroFiles.wxs", isPackage: true, 8600);
+            Assert.Equal(new[]
+            {
+                "8600",
+            }, messages);
+        }
+
+        [Fact]
+        public void MissingHarvestDirectoryIsAWarning()
+        {
+            var messages = BuildAndQueryComponentAndFileTables("BadDirectory.wxs", isPackage: true, 8601);
+            Assert.Equal(new[]
+            {
+                "8601",
+                "8601",
+            }, messages);
+        }
+
+        [Fact]
+        public void DuplicateFilesSomethingSomething()
+        {
+            var messages = BuildAndQueryComponentAndFileTables("DuplicateFiles.wxs", isPackage: true, 8602);
+            Assert.Equal(new[]
+            {
+                "8602",
+                "8602",
+                "8602",
+                "8602",
+            }, messages);
+        }
+
+        [Fact]
+        public void CanHarvestFilesInComponentGroup()
+        {
+            BuildQueryAssertFiles("ComponentGroup.wxs",  new[]
+            {
+                "FileName.Extension",
+                "test20.txt",
+                "test21.txt",
+                "test3.txt",
+                "test4.txt",
+            });
+        }
+
+        [Fact]
+        public void CanHarvestFilesInDirectory()
+        {
+            BuildQueryAssertFiles("Directory.wxs",  new[]
+            {
+                "test10.txt",
+                "test120.txt",
+                "test2.txt",
+                "test3.txt",
+                "test4.txt",
+            });
+        }
+
+        [Fact]
+        public void CanHarvestFilesInDirectoryRef()
+        {
+            BuildQueryAssertFiles("DirectoryRef.wxs", new[]
+            {
+                "notatest.txt",
+                "pleasedontincludeme.dat",
+                "test1.txt",
+                "test120.txt",
+                "test2.txt",
+                "test20.txt",
+                "test21.txt",
+                "test3.txt",
+                "test4.txt",
+            });
+        }
+
+        [Fact]
+        public void CanHarvestFilesInFeature()
+        {
+            var rows = BuildAndQueryComponentAndFileTables("Feature.wxs");
+
+            AssertFileComponentIds(3, rows);
+        }
+
+        [Fact]
+        public void CanHarvestFilesInFeatureGroup()
+        {
+            BuildQueryAssertFiles("FeatureGroup.wxs", new[]
+            {
+                "FileName.Extension",
+                "notatest.txt",
+                "pleasedontincludeme.dat",
+                "test1.txt",
+                "test2.txt",
+                "test20.txt",
+                "test21.txt",
+                "test3.txt",
+                "test4.txt",
+            });
+        }
+
+        [Fact]
+        public void CanHarvestFilesInFeatureRef()
+        {
+            BuildQueryAssertFiles("FeatureRef.wxs", new[]
+            {
+                "FileName.Extension",
+                "notatest.txt",
+                "pleasedontincludeme.dat",
+                "test1.txt",
+                "test2.txt",
+                "test20.txt",
+                "test21.txt",
+                "test3.txt",
+                "test4.txt",
+            });
+        }
+
+        [Fact]
+        public void CanHarvestFilesInFragments()
+        {
+            BuildQueryAssertFiles("Fragment.wxs", new[]
+            {
+                "notatest.txt",
+                "test1.txt",
+                "test2.txt",
+                "test3.txt",
+                "test4.txt",
+            });
+        }
+
+        [Fact]
+        public void CanHarvestFilesInModules()
+        {
+            BuildQueryAssertFiles("Module.wxs", new[]
+            {
+                "notatest.txt",
+                "test1.txt",
+                "test2.txt",
+                "test3.txt",
+                "test4.txt",
+            }, isPackage: false);
+        }
+
+        [Fact]
+        public void CanHarvestFilesWithBindPaths()
+        {
+            BuildQueryAssertFiles("BindPaths.wxs", new[]
+            {
+                "FileName.Extension",
+                "test1.txt",
+                "test10.txt",
+                "test120.txt",
+                "test2.txt",
+                "test20.txt",
+                "test21.txt",
+                "test3.txt",
+                "test4.txt",
+            });
+        }
+
+        [Fact]
+        public void HarvestedFilesUnderPackageWithAuthoredFeatureAreOrphaned()
+        {
+            var messages = BuildAndQueryComponentAndFileTables("PackageWithoutDefaultFeature.wxs", isPackage: true, 267);
+            Assert.Equal(new[]
+            {
+                "267",
+                "267",
+                "267",
+                "267",
+            }, messages);
+        }
+
+        [Fact]
+        public void CanHarvestFilesInStandardDirectory()
+        {
+            BuildQueryAssertFiles("StandardDirectory.wxs", new[]
+            {
+                "FileName.Extension",
+                "notatest.txt",
+                "pleasedontincludeme.dat",
+                "test1.txt",
+                "test10.txt",
+                "test120.txt",
+                "test2.txt",
+                "test20.txt",
+                "test21.txt",
+                "test3.txt",
+                "test4.txt",
+            });
+        }
+
+        [Fact]
+        public void CanHarvestFilesInFiveLines()
+        {
+            BuildQueryAssertFiles("PackageFiveLiner.wxs", new[]
+            {
+                "FileName.Extension",
+                "notatest.txt",
+                "pleasedontincludeme.dat",
+                "test20.txt",
+                "test21.txt",
+                "test3.txt",
+                "test4.txt",
+            });
+        }
+
+        private static void BuildQueryAssertFiles(string file, string[] expectedFileNames, bool isPackage = true, int? exitCode = null)
+        {
+            var rows = BuildAndQueryComponentAndFileTables(file, isPackage, exitCode);
+
+            var fileNames = AssertFileComponentIds(expectedFileNames.Length, rows);
+
+            Assert.Equal(expectedFileNames, fileNames);
+        }
+
+        private static string[] BuildAndQueryComponentAndFileTables(string file, bool isPackage = true, int? exitCode = null)
+        {
+            var folder = TestData.Get("TestData", "HarvestFiles");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var binFolder = Path.Combine(baseFolder, "bin");
+                var msiPath = Path.Combine(binFolder, isPackage ? "test.msi" : "test.msm");
+
+                var arguments = new[]
+                {
+                    "build",
+                    Path.Combine(folder, file),
+                    "-intermediateFolder", intermediateFolder,
+                    "-bindpath", folder,
+                    "-bindpath", @$"ToBeHarvested={folder}\files1",
+                    "-bindpath", @$"ToBeHarvested={folder}\files2",
+                    "-o", msiPath,
+                };
+
+                var result = WixRunner.Execute(arguments);
+
+                if (exitCode.HasValue)
+                {
+                    Assert.Equal(exitCode.Value, result.ExitCode);
+
+                    return result.Messages.Select(m => m.Id.ToString()).ToArray();
+                }
+                else
+                {
+                    result.AssertSuccess();
+
+                    return Query.QueryDatabase(msiPath, new[] { "Component", "File" })
+                        .OrderBy(s => s)
+                        .ToArray();
+                }
+            }
+        }
+
+        private static string[] AssertFileComponentIds(int fileCount, string[] rows)
+        {
+            var componentRows = rows.Where(row => row.StartsWith("Component:")).ToArray();
+            var fileRows = rows.Where(row => row.StartsWith("File:")).ToArray();
+
+            Assert.Equal(componentRows.Length, fileRows.Length);
+
+            // Component id == Component keypath == File id
+            foreach (var componentRow in componentRows)
+            {
+                var columns = componentRow.Split(':', '\t');
+                Assert.Equal(columns[1], columns[6]);
+            }
+
+            foreach (var fileRow in fileRows)
+            {
+                var columns = fileRow.Split(':', '\t');
+                Assert.Equal(columns[1], columns[2]);
+            }
+
+            Assert.Equal(fileCount, componentRows.Length);
+
+            var files = fileRows.Select(row => row.Split('\t')[2]);
+            var lfns = files.Select(name => name.Split('|'));
+
+            return fileRows
+                .Select(row => row.Split('\t')[2])
+                .Select(GetLFN)
+                .OrderBy(name => name).ToArray();
+
+            static string GetLFN(string possibleSfnLfnPair)
+            {
+                var parts = possibleSfnLfnPair.Split('|');
+                return parts[parts.Length - 1];
+            }
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/BadAuthoring.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/BadAuthoring.wxs
@@ -1,0 +1,7 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <ComponentGroup Id="Files">
+            <Files />
+        </ComponentGroup>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/BadDirectory.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/BadDirectory.wxs
@@ -1,0 +1,14 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <Feature Id="ProductFeature">
+            <ComponentGroupRef Id="Files" />
+        </Feature>
+
+        <ComponentGroup Id="Files" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="$(sys.SOURCEFILEDIR)files2">
+            <Files Include="MissingDirectory\**" />
+            <Files Include="ThisDirectoryIsAlsoMissing\**" />
+        </ComponentGroup>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/BindPaths.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/BindPaths.wxs
@@ -1,0 +1,16 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="HarvestedFiles" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <Feature Id="ProductFeature">
+            <ComponentGroupRef Id="Files" />
+        </Feature>
+
+        <ComponentGroup Id="Files" Directory="ProgramFilesFolder" Subdirectory="HarvestedFiles">
+            <Files Include="!(bindpath.ToBeHarvested)\**">
+                <Exclude Files="!(bindpath.ToBeHarvested)\notatest.txt" />
+                <Exclude Files="**\pleasedontincludeme.dat" />
+            </Files>
+        </ComponentGroup>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/ComponentGroup.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/ComponentGroup.wxs
@@ -1,0 +1,16 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <Feature Id="ProductFeature">
+            <ComponentGroupRef Id="Files" />
+        </Feature>
+
+        <ComponentGroup Id="Files" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="$(sys.SOURCEFILEDIR)files2">
+            <Files Include="**">
+                <Exclude Files="notatest.txt" />
+                <Exclude Files="files2_sub2\pleasedontincludeme.dat" />
+            </Files>
+        </ComponentGroup>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/Directory.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/Directory.wxs
@@ -1,0 +1,20 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" FileSource="$(sys.SOURCEFILEDIR)">
+                <!-- Relies on default-feature feature to include naked files in package. -->
+                <Files Include="files1\**">
+                    <Exclude Files="files1\test1.txt" />
+                </Files>
+
+                <Files Include="files2\**">
+                    <Exclude Files="**\*.Extension" />
+                    <Exclude Files="files2\notatest.txt" />
+                    <Exclude Files="files2\files2_sub2\**" />
+                </Files>
+            </Directory>
+        </StandardDirectory>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/DirectoryRef.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/DirectoryRef.wxs
@@ -1,0 +1,21 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <DirectoryRef Id="INSTALLFOLDER">
+            <!-- Relies on default-feature feature to include naked files in package. -->
+            <Files Include="files1\**">
+                <Exclude Files="files1\files1_sub1\*" />
+            </Files>
+            <Files Include="files2\**">
+                <Exclude Files="$(sys.SOURCEFILEDIR)\files2\**.extension" />
+            </Files>
+        </DirectoryRef>
+    </Package>
+
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/DuplicateFiles.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/DuplicateFiles.wxs
@@ -1,0 +1,23 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <Feature Id="ProductFeature">
+            <ComponentGroupRef Id="FilesA" />
+            <ComponentGroupRef Id="FilesB" />
+        </Feature>
+
+    </Package>
+
+    <Fragment>
+        <ComponentGroup Id="FilesA" Directory="ProgramFilesFolder" Subdirectory="MsiPackage">
+            <Files Include="files1\**" />
+        </ComponentGroup>
+    </Fragment>
+
+    <Fragment>
+        <ComponentGroup Id="FilesB" Directory="ProgramFilesFolder" Subdirectory="MsiPackage">
+            <Files Include="files1\**" />
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/Feature.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/Feature.wxs
@@ -1,0 +1,25 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <Feature Id="ProductFeature">
+            <Files
+                Directory="ProgramFiles6432Folder"
+                Subdirectory="Example Product"
+                Include="files1\*">
+                <Exclude Files="files1\test1.txt" />
+            </Files>
+
+            <!--
+            `$(sys.SOURCEFILEDIR)` is equivalent to the above (i.e., the default),
+            but this validates that preprocessor variables are happy here.
+            -->
+            <Files
+                Directory="ProgramFiles6432Folder"
+                Subdirectory="Example Product\Assets"
+                Include="$(sys.SOURCEFILEDIR)\files2\*">
+                <Exclude Files="$(sys.SOURCEFILEDIR)\files2\notatest.txt" />
+            </Files>
+        </Feature>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/FeatureGroup.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/FeatureGroup.wxs
@@ -1,0 +1,25 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <Feature Id="ProductFeature">
+            <FeatureGroupRef Id="ProductFeatureGroup" />
+        </Feature>
+    </Package>
+
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+
+    <Fragment>
+        <FeatureGroup Id="ProductFeatureGroup">
+            <Files Directory="INSTALLFOLDER" Include="files1\**">
+                <Exclude Files="files1\files1_sub1\**" />
+            </Files>
+
+            <Files Directory="INSTALLFOLDER" Subdirectory="assets" Include="files2\**" />
+        </FeatureGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/FeatureRef.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/FeatureRef.wxs
@@ -1,0 +1,23 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <FeatureRef Id="ProductFeature">
+            <Files Directory="INSTALLFOLDER" Include="files1\**">
+                <Exclude Files="files1\files1_sub1\**" />
+            </Files>
+
+            <Files Directory="INSTALLFOLDER" Subdirectory="assets" Include="files2\**" />
+        </FeatureRef>
+    </Package>
+
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+
+    <Fragment>
+        <Feature Id="ProductFeature" />
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/Fragment.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/Fragment.wxs
@@ -1,0 +1,24 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <FeatureGroupRef Id="FeatureGroup1" />
+        <FeatureGroupRef Id="FeatureGroup2" />
+    </Package>
+
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+
+    <Fragment>
+        <FeatureGroup Id="FeatureGroup1" />
+        <Files Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Include="files1\*" />
+    </Fragment>
+
+    <Fragment>
+        <FeatureGroup Id="FeatureGroup2" />
+        <Files Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Include="files2\*" />
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/Module.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/Module.wxs
@@ -1,0 +1,6 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Module Id="MergeModule" Guid="e535b765-1019-4a4f-b3ea-ae28870e6d73" Language="1033" Version="1.0.0.0">
+        <Files Directory="ProgramFilesFolder" Subdirectory="MergeModule" Include="files1\*" />
+        <Files Directory="ProgramFilesFolder" Subdirectory="MergeModule" Include="files2\*" />
+    </Module>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/PackageFiveLiner.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/PackageFiveLiner.wxs
@@ -1,0 +1,5 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <Files Include="files2\**" />
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/PackageWithoutDefaultFeature.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/PackageWithoutDefaultFeature.wxs
@@ -1,0 +1,15 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <Files Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Include="files1\**" />
+
+        <Feature Id="ProductFeature">
+            <ComponentGroupRef Id="Files" />
+        </Feature>
+
+        <ComponentGroup Id="Files" Directory="ProgramFilesFolder" Subdirectory="MsiPackage">
+            <Files Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Include="files2\*" />
+        </ComponentGroup>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/StandardDirectory.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/StandardDirectory.wxs
@@ -1,0 +1,11 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <StandardDirectory Id="ProgramFiles6432Folder">
+            <!-- Relies on default-feature feature to include naked files in package. -->
+            <Files Subdirectory="MsiPackage" Include="files1\**" />
+            <Files Subdirectory="MsiPackage" Include="files2\**" />
+        </StandardDirectory>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/ZeroFiles.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/ZeroFiles.wxs
@@ -1,0 +1,15 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <Feature Id="ProductFeature">
+            <ComponentGroupRef Id="Files" />
+        </Feature>
+
+        <ComponentGroup Id="Files" Directory="ProgramFilesFolder" Subdirectory="MsiPackage" Source="$(sys.SOURCEFILEDIR)files2">
+            <Files Include="**">
+                <Exclude Files="**" />
+            </Files>
+        </ComponentGroup>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files1/files1_sub1/files1_sub2/test120.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files1/files1_sub1/files1_sub2/test120.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files1/files1_sub1/test10.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files1/files1_sub1/test10.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files1/test1.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files1/test1.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files1/test2.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files1/test2.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/files2_sub2/pleasedontincludeme.dat
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/files2_sub2/pleasedontincludeme.dat
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/files2_sub2/test20.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/files2_sub2/test20.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/files2_sub2/test21.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/files2_sub2/test21.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/files2_sub3/FileName.Extension
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/files2_sub3/FileName.Extension
@@ -1,0 +1,14 @@
+﻿// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration.TestData.HarvestFiles.files2.files2_sub3
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Text;
+    using System.Threading.Tasks;
+
+    internal class FileName
+    {
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/notatest.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/notatest.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/test3.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/test3.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/test4.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/files2/test4.txt
@@ -1,0 +1,1 @@
+This is test.txt.


### PR DESCRIPTION
Implements https://github.com/wixtoolset/issues/issues/7857.

Like [naked files](https://github.com/wixtoolset/issues/issues/7696), `Files` elements can appear where `Component` elements do in WiX v4. The optimizer enumerates files and directories, generating single-file components as it goes. MSBuild-like wildcards (including `**`) are supported. `Excludes` child elements lets you exclude files that would otherwise be captured by wildcards.