### PR TITLE
Allow MsiProperty/@Value to be an empty string.

### DIFF
--- a/src/test/burn/TestData/VariableTests/BundleA/BundleA.wxs
+++ b/src/test/burn/TestData/VariableTests/BundleA/BundleA.wxs
@@ -8,6 +8,7 @@
       <MsiPackage Id="PackageA" SourceFile="$(var.PackageA.TargetPath)">
         <MsiProperty Name="INSTALLLOCATION" Value="[INSTALLLOCATION]" />
         <MsiProperty Name="LICENSEKEY" Value="[LICENSEKEY]" />
+        <MsiProperty Name="BLANKPROPERTY" Value="" />
       </MsiPackage>
     </PackageGroup>
 

--- a/src/test/burn/WixToolsetTest.BurnE2E/VariableTests.cs
+++ b/src/test/burn/WixToolsetTest.BurnE2E/VariableTests.cs
@@ -30,7 +30,7 @@ namespace WixToolsetTest.BurnE2E
             // Burn logging its command line.
             Assert.True(LogVerifier.MessageInLogFile(logFilePath, "InstallLocation=nothingtoseehere licensekey=*****"));
             // Burn logging the MSI install command line.
-            Assert.True(LogVerifier.MessageInLogFile(logFilePath, "INSTALLLOCATION=\"nothingtoseehere\" LICENSEKEY=\"*****\""));
+            Assert.True(LogVerifier.MessageInLogFile(logFilePath, "INSTALLLOCATION=\"nothingtoseehere\" LICENSEKEY=\"*****\" BLANKPROPERTY=\"\""));
             Assert.False(LogVerifier.MessageInLogFile(logFilePath, "supersecretkey"));
         }
 

--- a/src/wix/WixToolset.Core/Compiler_Bundle.cs
+++ b/src/wix/WixToolset.Core/Compiler_Bundle.cs
@@ -3340,7 +3340,7 @@ namespace WixToolset.Core
                             name = this.Core.GetAttributeMsiPropertyNameValue(sourceLineNumbers, attrib);
                             break;
                         case "Value":
-                            value = this.Core.GetAttributeValue(sourceLineNumbers, attrib);
+                            value = this.Core.GetAttributeValue(sourceLineNumbers, attrib, EmptyRule.CanBeEmpty);
                             break;
                         case "Condition":
                             condition = this.Core.GetAttributeValue(sourceLineNumbers, attrib);

--- a/src/wix/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -177,6 +177,15 @@ namespace WixToolsetTest.CoreIntegration
                     {
                         "<Payload Id='test.msi' FilePath='test.msi' FileSize='*' Hash='*' Packaging='embedded' SourcePath='a0' Container='WixAttachedContainer' />",
                     }, msiPayloads);
+
+                    var msiProperties = extractResult.GetManifestTestXmlLines("/burn:BurnManifest/burn:Chain/burn:MsiPackage[@Id='test.msi']/burn:MsiProperty", ignoreAttributesByElementName);
+                    WixAssert.CompareLineByLine(new[]
+                    {
+                        "<MsiProperty Id='TEST' Value='1' />",
+                        "<MsiProperty Id='TESTBLANK' Value='' />",
+                        "<MsiProperty Id='ARPSYSTEMCOMPONENT' Value='1' />",
+                        "<MsiProperty Id='MSIFASTINSTALL' Value='7' />",
+                    }, msiProperties);
                 }
 
                 var manifestResource = new Resource(ResourceType.Manifest, "#1", 1033);

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SimpleBundle/Bundle.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/SimpleBundle/Bundle.wxs
@@ -6,6 +6,7 @@
     <Chain>
       <MsiPackage SourceFile="test.msi">
         <MsiProperty Name="TEST" Value="1" />
+        <MsiProperty Name="TESTBLANK" Value="" />
       </MsiPackage>
     </Chain>
   </Bundle>


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/7798.