### PR TITLE
Support loc strings for Directory/@ShortName.

### DIFF
--- a/src/wix/WixToolset.Core/CompilerCore.cs
+++ b/src/wix/WixToolset.Core/CompilerCore.cs
@@ -703,7 +703,9 @@ namespace WixToolset.Core
 
             if (0 < value.Length)
             {
-                if (!this.parseHelper.IsValidShortFilename(value, allowWildcards) && !Common.ContainsValidBinderVariable(value))
+                if (!this.parseHelper.IsValidShortFilename(value, allowWildcards)
+                    && !Common.ContainsValidBinderVariable(value)
+                    && !this.IsValidLocIdentifier(value))
                 {
                     this.Write(ErrorMessages.IllegalShortFilename(sourceLineNumbers, attribute.Parent.Name.LocalName, attribute.Name.LocalName, value));
                 }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
@@ -233,6 +233,7 @@ namespace WixToolsetTest.CoreIntegration
                     "-sw1031", // this is expected for this test
                     Path.Combine(folder, "DefaultDir", "DefaultDir.wxs"),
                     Path.Combine(folder, "ProductWithComponentGroupRef", "Product.wxs"),
+                    "-loc", Path.Combine(folder, "DefaultDir", "Package.en-us.wxl"),
                     "-bindpath", Path.Combine(folder, "SingleFile", "data"),
                     "-intermediateFolder", intermediateFolder,
                     "-o", msiPath
@@ -252,6 +253,7 @@ namespace WixToolsetTest.CoreIntegration
                     "Directory:GitFolder\tINSTALLFOLDER\t69sdfw2d|.git",
                     "Directory:INSTALLFOLDER\tProgramFiles6432Folder\t1egc1laj|MsiPackage",
                     "Directory:NAMEANDSHORTNAME\tINSTALLFOLDER\tSHORTNAM|NameAndShortName",
+                    "Directory:NAMEANDSHORTNAMEVIALOCSTRING\tINSTALLFOLDER\tSHRTNAME|ShortName",
                     "Directory:NAMEANDSHORTSOURCENAME\tINSTALLFOLDER\tNAMEASSN|NameAndShortSourceName",
                     "Directory:NAMEWITHSHORTVALUE\tINSTALLFOLDER\tSHORTVAL",
                     "Directory:ProgramFiles6432Folder\tProgramFilesFolder\t.",

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultDir/DefaultDir.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultDir/DefaultDir.wxs
@@ -10,6 +10,7 @@
         <DirectoryRef Id="INSTALLFOLDER">
             <Directory Id="DUPLICATENAMEANDSHORTNAME" Name="duplicat" ShortName="duplicat"></Directory>
             <Directory Id="NAMEWITHSHORTVALUE" Name="SHORTVAL"></Directory>
+            <Directory Id="NAMEANDSHORTNAMEVIALOCSTRING" Name="ShortName" ShortName="!(loc.ShortVal)"></Directory>
             <Directory Id="NAMEANDSHORTNAME" Name="NameAndShortName" ShortName="SHORTNAM"></Directory>
             <Directory Id="SHORTNAMEONLY" Name="SHORTONL"></Directory>
             <Directory Id="SOURCENAME" Name="NameAndSourceName" SourceName="SourceNameWithName"></Directory>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultDir/Package.en-us.wxl
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultDir/Package.en-us.wxl
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<WixLocalization xmlns="http://wixtoolset.org/schemas/v4/wxl" Culture="en-US">
+  <String Id="ShortVal" Value="SHRTNAME" />
+</WixLocalization>


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/7935.