### PR TITLE
Allow default major upgrade to be rescheduled.

### DIFF
--- a/src/wix/WixToolset.Core/Link/AddDefaultSymbolsCommand.cs
+++ b/src/wix/WixToolset.Core/Link/AddDefaultSymbolsCommand.cs
@@ -99,6 +99,7 @@ namespace WixToolset.Core.Link
                     SequenceTable = SequenceTable.InstallExecuteSequence,
                     Action = "RemoveExistingProducts",
                     After = "InstallValidate",
+                    Overridable = true,
                 },
                 new WixSimpleReferenceSymbol(packageSymbol.SourceLineNumbers)
                 {
@@ -126,7 +127,10 @@ namespace WixToolset.Core.Link
                 {
                     var symbolWithSection = new SymbolWithSection(section, symbol);
                     var fullName = symbolWithSection.GetFullName();
-                    this.Find.SymbolsByName.Add(fullName, symbolWithSection);
+                    if (!this.Find.SymbolsByName.ContainsKey(fullName))
+                    {
+                        this.Find.SymbolsByName.Add(fullName, symbolWithSection);
+                    }
                 }
             }
         }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultMajorUpgradeReschedule/DefaultMajorUpgradeReschedule.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultMajorUpgradeReschedule/DefaultMajorUpgradeReschedule.wxs
@@ -1,0 +1,7 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="DefaultMajorUpgradeReschedule" Language="1033" Version="2.0.0" Manufacturer="Example Corporation" UpgradeCode="{3F2494B1-AF5E-48ED-9C9E-843F1DB2BC97}">
+        <InstallExecuteSequence>
+            <RemoveExistingProducts After="InstallFinalize" />
+        </InstallExecuteSequence>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
@@ -74,6 +74,20 @@ namespace WixToolsetTest.CoreIntegration
         }
 
         [Fact]
+        public void CanRescheduleRemoveExistingProductsWithDefaultMajorUpgrade()
+        {
+            var folder = TestData.Get("TestData", "DefaultMajorUpgradeReschedule");
+            var build = new Builder(folder, new Type[] { }, new[] { folder });
+
+            var results = build.BuildAndQuery(Build, "InstallExecuteSequence").Where(r => r.StartsWith("InstallExecuteSequence:RemoveExistingProducts") || r.StartsWith("InstallExecuteSequence:InstallFinalize")).ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                "InstallExecuteSequence:InstallFinalize\t\t6600",
+                "InstallExecuteSequence:RemoveExistingProducts\t\t6601",
+            }, results);
+        }
+
+        [Fact]
         public void CanOverrideDefaultMajorUpgradeLaunchConditionMessage()
         {
             var folder = TestData.Get("TestData", "DefaultMajorUpgradeOverride");


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/8046.