### PR TITLE
Report E_MOREDATA from Bal functions when string buffer too small

### DIFF
--- a/src/api/burn/balutil/BalBootstrapperEngine.cpp
+++ b/src/api/burn/balutil/BalBootstrapperEngine.cpp
@@ -216,6 +216,10 @@ public: // IBootstrapperEngine
         if (wzValue)
         {
             hr = ::StringCchCopyW(wzValue, *pcchValue, results.wzValue);
+            if (E_INSUFFICIENT_BUFFER == hr)
+            {
+                hr = E_MOREDATA;
+            }
         }
         else if (results.cchValue)
         {
@@ -292,6 +296,10 @@ public: // IBootstrapperEngine
         if (wzValue)
         {
             hr = ::StringCchCopyW(wzValue, *pcchValue, results.wzValue);
+            if (E_INSUFFICIENT_BUFFER == hr)
+            {
+                hr = E_MOREDATA;
+            }
         }
         else if (results.cchValue)
         {
@@ -373,6 +381,10 @@ public: // IBootstrapperEngine
         if (wzValue)
         {
             hr = ::StringCchCopyW(wzValue, *pcchValue, results.wzValue);
+            if (E_INSUFFICIENT_BUFFER == hr)
+            {
+                hr = E_MOREDATA;
+            }
         }
         else if (results.cchValue)
         {
@@ -449,6 +461,10 @@ public: // IBootstrapperEngine
         if (wzOut)
         {
             hr = ::StringCchCopyW(wzOut, *pcchOut, results.wzOut);
+            if (E_INSUFFICIENT_BUFFER == hr)
+            {
+                hr = E_MOREDATA;
+            }
         }
         else if (results.cchOut)
         {
@@ -525,6 +541,10 @@ public: // IBootstrapperEngine
         if (wzOut)
         {
             hr = ::StringCchCopyW(wzOut, *pcchOut, results.wzOut);
+            if (E_INSUFFICIENT_BUFFER == hr)
+            {
+                hr = E_MOREDATA;
+            }
         }
         else if (results.cchOut)
         {

--- a/src/test/burn/TestData/WixStdBaTests/BalCondition/BalCondition.wixproj
+++ b/src/test/burn/TestData/WixStdBaTests/BalCondition/BalCondition.wixproj
@@ -1,0 +1,18 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<Project Sdk="WixToolset.Sdk">
+  <PropertyGroup>
+    <OutputType>Bundle</OutputType>
+    <BA>hyperlinkLicense</BA>
+    <UpgradeCode>{42CCE8AB-777A-481F-9EA2-0B5B10179E8A}</UpgradeCode>
+    <DefineConstants>$(DefineConstants);Version=1.0</DefineConstants>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\PackageA\PackageA.wixproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="WixToolset.BootstrapperApplications.wixext" />
+  </ItemGroup>
+</Project>

--- a/src/test/burn/TestData/WixStdBaTests/BalCondition/BalCondition.wxs
+++ b/src/test/burn/TestData/WixStdBaTests/BalCondition/BalCondition.wxs
@@ -1,0 +1,18 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
+  <Bundle Name="~$(var.TestGroupName) - $(var.BundleName)" Version="$(var.Version)" UpgradeCode="$(var.UpgradeCode)" Compressed="yes">
+    <Log Prefix="~$(var.TestGroupName)_$(var.BundleName)" />
+
+    <BootstrapperApplication>
+      <bal:WixStandardBootstrapperApplication LicenseUrl="" Theme="hyperlinkLargeLicense" SuppressOptionsUI="yes" SuppressDowngradeFailure="yes" />
+    </BootstrapperApplication>
+
+    <bal:Condition Condition="1" Message="This is a first condition that we need to meet" />
+    <bal:Condition Condition="1" Message="This is a second condition that we need to meet with a longer message" />
+
+    <Chain>
+      <MsiPackage Id="PackageA" SourceFile="$(var.PackageA.TargetPath)" />
+    </Chain>
+  </Bundle>
+</Wix>

--- a/src/test/burn/WixToolsetTest.BurnE2E/WixStdBaTests.cs
+++ b/src/test/burn/WixToolsetTest.BurnE2E/WixStdBaTests.cs
@@ -10,6 +10,23 @@ namespace WixToolsetTest.BurnE2E
         public WixStdBaTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper) { }
 
         [RuntimeFact]
+        public void SucceedsWithMultipleConditions()
+        {
+            var packageA = this.CreatePackageInstaller("PackageA");
+            var bundle = this.CreateBundleInstaller("BalCondition");
+
+            packageA.VerifyInstalled(false);
+
+            bundle.Install();
+            bundle.VerifyRegisteredAndInPackageCache();
+            packageA.VerifyInstalled(true);
+
+            bundle.Uninstall();
+            bundle.VerifyUnregisteredAndRemovedFromPackageCache();
+            packageA.VerifyInstalled(false);
+        }
+
+        [RuntimeFact]
         public void ExitsWithErrorWhenDowngradingWithoutSuppression()
         {
             var packageA = this.CreatePackageInstaller("PackageA");


### PR DESCRIPTION
WiX v4 (and probably v3) standardized on the error code E_MOREDATA when string buffers were too small instead of E_INSUFFICIIENT_BUFFER. This fixes v5 to match in a few missing cases.

Fixes wixtoolset/issues#8094