### PR TITLE
CustomActionProxy: restore current directory after run.

### DIFF
--- a/src/dtf/WixToolset.Dtf.WindowsInstaller/CustomActionProxy.cs
+++ b/src/dtf/WixToolset.Dtf.WindowsInstaller/CustomActionProxy.cs
@@ -101,8 +101,13 @@ namespace WixToolset.Dtf.WindowsInstaller
                 return (int) ActionResult.Failure;
             }
 
+            string originalCurrentDirectory = null;
+
             try
             {
+                // Save current directory to restore after custom action invocation.
+                originalCurrentDirectory = Environment.CurrentDirectory;
+
                 // Set the current directory to the location of the extracted files.
                 Environment.CurrentDirectory =
                     AppDomain.CurrentDomain.BaseDirectory;
@@ -141,6 +146,20 @@ namespace WixToolset.Dtf.WindowsInstaller
                 session.Log("Exception thrown by custom action:");
                 session.Log(ex.ToString());
                 return (int) ActionResult.Failure;
+            }
+            finally
+            {
+                try
+                {
+                    if (originalCurrentDirectory != null)
+                    {
+                        Environment.CurrentDirectory = originalCurrentDirectory;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    session.Log("Cannot set current directory: {0}", ex.Message);
+                }
             }
         }
 


### PR DESCRIPTION
The CustomActionProxy changes the current directory, but doesn't restore it after invocation.

It causes the problem that custom action cannot delete temp directory.

![unnamed](https://github.com/wixtoolset/wix/assets/64201197/da0eaf5e-f6e0-4181-8ec1-8add7b452601)
