### PR TITLE
Add required VS components and configure VS in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,9 +32,9 @@ jobs:
         with:
           fetch-depth: 0
 
-      # - name: Configure Visual Studio
-      #   shell: cmd
-      #   run: ./src/vs_config.cmd
+      - name: Configure Visual Studio
+        shell: cmd
+        run: ./src/vs_config.cmd
 
       - name: Install sign tool
         if: (github.ref == 'refs/heads/master')

--- a/src/wix.vsconfig
+++ b/src/wix.vsconfig
@@ -1,6 +1,7 @@
 {
   "version": "1.0",
   "components": [
+    "Microsoft.VisualStudio.Component.VC.v141.x86.x64.Spectre",
     "Microsoft.VisualStudio.Component.VC.v141.ARM64.Spectre"
   ]
 }


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/8211 by implementing option 1. (Reverts https://github.com/wixtoolset/wix/pull/123)
Adds around 2-4 mins to build time.
Could be easily backported to v5 and v4.