### PR TITLE
Build native code with VC v143 toolset only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ This repository contains the WiX Toolset codebase.
 | .NET Framework 4.7.2 SDK |
 | .NET Framework 4.7.2 targeting pack |
 | .NET Framework 4.6.2 targeting pack |
-| MSVC v141 - VS 2017 C++ ARM64 build tools (v14.16) |
-| MSVC v141 - VS 2017 C++ x64/x86 build tools (v14.16) |
 | MSVC v143 - VS 2022 C++ ARM64/ARM64EC build tools (Latest) |
 | MSVC v143 - VS 2022 C++ x64/x86 build tools (Latest) |
 | Git for Windows |

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -20,7 +20,7 @@
     <OutputPath>$(BaseOutputPath)$(Configuration)\</OutputPath>
 
     <!-- This is C++-specific but used from managed projects to pick up native build artifacts. -->
-    <WixNativeSdkLibraryToolset>v141</WixNativeSdkLibraryToolset>
+    <WixNativeSdkLibraryToolset>v143</WixNativeSdkLibraryToolset>
     <PlatformToolset Condition=" '$(ConfigurationType)' == 'StaticLibrary' ">$(WixNativeSdkLibraryToolset)</PlatformToolset>
     <PlatformToolset Condition=" '$(PlatformToolset)' == '' ">v143</PlatformToolset>
 

--- a/src/Directory.vcxproj.props
+++ b/src/Directory.vcxproj.props
@@ -10,9 +10,8 @@
     <OutDir>$(OutputPath)$(PlatformFolder)\</OutDir>
   </PropertyGroup>
 
-  <!-- This is needed for v141 toolset, which doesn't understand `10.0` -->
   <PropertyGroup Condition="'$(WindowsTargetPlatformVersion)'==''">
-    <WindowsTargetPlatformVersion>$([Microsoft.Build.Utilities.ToolLocationHelper]::GetLatestSDKTargetPlatformVersion('Windows', '10.0'))</WindowsTargetPlatformVersion>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(CLRSupport)'!='true' ">

--- a/src/api/burn/WixToolset.BootstrapperApplicationApi/WixToolset.BootstrapperApplicationApi.nuspec
+++ b/src/api/burn/WixToolset.BootstrapperApplicationApi/WixToolset.BootstrapperApplicationApi.nuspec
@@ -39,8 +39,8 @@
     <file src="$projectFolder$\..\balutil\inc\*" target="build\native\include" />
     <file src="$projectFolder$\..\inc\BootstrapperApplicationTypes.h" target="build\native\include" />
     <file src="$projectFolder$\..\inc\BootstrapperEngineTypes.h" target="build\native\include" />
-    <file src="v141\x86\balutil.lib" target="build\native\v14\x86" />
-    <file src="v141\x64\balutil.lib" target="build\native\v14\x64" />
-    <file src="v141\ARM64\balutil.lib" target="build\native\v14\ARM64" />
+    <file src="v143\x86\balutil.lib" target="build\native\v14\x86" />
+    <file src="v143\x64\balutil.lib" target="build\native\v14\x64" />
+    <file src="v143\ARM64\balutil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/api/burn/bextutil/bextutil.nuspec
+++ b/src/api/burn/bextutil/bextutil.nuspec
@@ -23,8 +23,8 @@
     <file src="$projectFolder$\inc\*" target="build\native\include" />
     <file src="$projectFolder$\..\inc\BootstrapperExtensionTypes.h" target="build\native\include" />
     <file src="$projectFolder$\..\inc\BootstrapperExtensionEngineTypes.h" target="build\native\include" />
-    <file src="..\..\v141\x86\bextutil.lib" target="build\native\v14\x86" />
-    <file src="..\..\v141\x64\bextutil.lib" target="build\native\v14\x64" />
-    <file src="..\..\v141\ARM64\bextutil.lib" target="build\native\v14\ARM64" />
+    <file src="..\..\v143\x86\bextutil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\x64\bextutil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\ARM64\bextutil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/ext/Bal/wixstdfn/wixstdfn.nuspec
+++ b/src/ext/Bal/wixstdfn/wixstdfn.nuspec
@@ -26,8 +26,8 @@
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\..\..\..\internal\images\wix.png" />
     <file src="$projectFolder$\inc\*" target="lib\native\include" />
-    <file src="..\..\v141\x86\wixstdfn.lib" target="lib\native\v14\x86" />
-    <file src="..\..\v141\x64\wixstdfn.lib" target="lib\native\v14\x64" />
-    <file src="..\..\v141\ARM64\wixstdfn.lib" target="lib\native\v14\ARM64" />
+    <file src="..\..\v143\x86\wixstdfn.lib" target="lib\native\v14\x86" />
+    <file src="..\..\v143\x64\wixstdfn.lib" target="lib\native\v14\x64" />
+    <file src="..\..\v143\ARM64\wixstdfn.lib" target="lib\native\v14\ARM64" />
   </files>
 </package>

--- a/src/libs/dutil/WixToolset.DUtil/dutil.nuspec
+++ b/src/libs/dutil/WixToolset.DUtil/dutil.nuspec
@@ -18,8 +18,8 @@
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\..\..\..\internal\images\wix.png" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v141\x64\dutil.lib" target="build\native\v14\x64" />
-    <file src="..\..\v141\x86\dutil.lib" target="build\native\v14\x86" />
-    <file src="..\..\v141\ARM64\dutil.lib" target="build\native\v14\ARM64" />
+    <file src="..\..\v143\x64\dutil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\x86\dutil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\ARM64\dutil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/libs/wcautil/WixToolset.WcaUtil/wcautil.nuspec
+++ b/src/libs/wcautil/WixToolset.WcaUtil/wcautil.nuspec
@@ -21,8 +21,8 @@
     <file src="$projectFolder$\build\$id$.props" target="build\" />
     <file src="$projectFolder$\..\..\..\internal\images\wix.png" />
     <file src="$projectFolder$\inc\*" target="build\native\include" />
-    <file src="..\..\v141\x64\wcautil.lib" target="build\native\v14\x64" />
-    <file src="..\..\v141\x86\wcautil.lib" target="build\native\v14\x86" />
-    <file src="..\..\v141\ARM64\wcautil.lib" target="build\native\v14\ARM64" />
+    <file src="..\..\v143\x64\wcautil.lib" target="build\native\v14\x64" />
+    <file src="..\..\v143\x86\wcautil.lib" target="build\native\v14\x86" />
+    <file src="..\..\v143\ARM64\wcautil.lib" target="build\native\v14\ARM64" />
   </files>
 </package>

--- a/src/wix.vsconfig
+++ b/src/wix.vsconfig
@@ -1,6 +1,5 @@
 {
   "version": "1.0",
   "components": [
-    "Microsoft.VisualStudio.Component.VC.v141.ARM64.Spectre"
   ]
 }


### PR DESCRIPTION
v143 output is compatible back to VS2017 (at least).

Fixes https://github.com/wixtoolset/issues/issues/8211.