### PR TITLE
Error message for 'logon as service' is not currently localised.

### DIFF
--- a/src/ext/Util/wixlib/UtilExtension.wxs
+++ b/src/ext/Util/wixlib/UtilExtension.wxs
@@ -9,7 +9,7 @@
             <Error Id="$(var.msierrUSRFailedUserCreate)" Message="!(loc.msierrUSRFailedUserCreate)" />
             <Error Id="$(var.msierrUSRFailedUserCreatePswd)" Message="!(loc.msierrUSRFailedUserCreatePswd)" />
             <Error Id="$(var.msierrUSRFailedUserGroupAdd)" Message="!(loc.msierrUSRFailedUserGroupAdd)" />
-            <Error Id="$(var.msierrUSRFailedGrantLogonAsService)" Message="Failed to grant 'logon as service' rights to user.  ([2]   [3]   [4]   [5])" />
+            <Error Id="$(var.msierrUSRFailedGrantLogonAsService)" Message="!(loc.msierrUSRFailedGrantLogonAsService)" />
             <Error Id="$(var.msierrUSRFailedUserCreateExists)" Message="!(loc.msierrUSRFailedUserCreateExists)" />
         </UI>
     </Fragment>

--- a/src/ext/Util/wixlib/de-de.wxl
+++ b/src/ext/Util/wixlib/de-de.wxl
@@ -5,6 +5,7 @@
     <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="Konnte den Benutzer nicht anlegen. ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="Konnte den Benutzer auf Grund eines falschen Passwortes nicht anlegen. ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="Konnte Benutzer nicht zur Gruppe hinzufügen. ([2]   [3]   [4]   [5])" />
+    <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="Konnte den Benutzer nicht gewähren 'Anmelden als ein Service' Rechte. ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="Konnte den Benutzer nicht anlegen, da er bereits existierte. ([2]   [3]   [4]   [5])" />
 
     <String Id="msierrSMBFailedCreate" Overridable="yes" Value="Konnte Netzwerkfreigabe nicht anlegen. ([2]   [3]   [4]   [5])" />

--- a/src/ext/Util/wixlib/en-us.wxl
+++ b/src/ext/Util/wixlib/en-us.wxl
@@ -5,6 +5,7 @@
     <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="Failed to create user.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="Failed to create user due to invalid password.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="Failed to add user to group.  ([2]   [3]   [4]   [5])" />
+    <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="Failed to grant 'logon as service' rights to user. ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="Failed to create user because it already exists.  ([2]   [3]   [4]   [5])" />
 
     <String Id="msierrSMBFailedCreate" Overridable="yes" Value="Failed to create network share.  ([2]   [3]   [4]   [5])" />

--- a/src/ext/Util/wixlib/es-es.wxl
+++ b/src/ext/Util/wixlib/es-es.wxl
@@ -4,6 +4,7 @@
   <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="La creación del usuario ha fracasado. ([2] [3] [4] [5])" />
   <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="La creación del usuario ha fracasado porque la contraseña es incorrecta. ([2] [3] [4] [5])" />
   <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="El aditamento del usuario al grupo ha fracasado. ([2] [3] [4] [5])" />
+  <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="No se pudieron otorgar derechos de 'iniciar sesión como servicio' al usuario. ([2] [3] [4] [5])" />
   <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="La creación del usuario ha fracasado porque ya existe. ([2] [3] [4] [5])" />
 
   <String Id="msierrSMBFailedCreate" Overridable="yes" Value="La creación de la red compartida ha fracasado. ([2] [3] [4] [5])" />

--- a/src/ext/Util/wixlib/fr-fr.wxl
+++ b/src/ext/Util/wixlib/fr-fr.wxl
@@ -4,6 +4,7 @@
   <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="La création de l'utilisateur a échoué.  ([2]   [3]   [4]   [5])" />
   <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="La création de l'utilisateur a échoué car le mot de passe est invalide.  ([2]   [3]   [4]   [5])" />
   <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="L'ajout de l'utilisateur au groupe a échoué.  ([2]   [3]   [4]   [5])" />
+  <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="Échec de l'octroi des droits de « connexion en tant que service » à l'utilisateur.  ([2]   [3]   [4]   [5])" />
   <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="La création de l'utilisateur a échoué car il existe dejà.  ([2]   [3]   [4]   [5])" />
 
   <String Id="msierrSMBFailedCreate" Overridable="yes" Value="La création du partage reseau a échoué.  ([2]   [3]   [4]   [5])" />

--- a/src/ext/Util/wixlib/it-it.wxl
+++ b/src/ext/Util/wixlib/it-it.wxl
@@ -5,6 +5,7 @@
     <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="Impossibile creare l'utente.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="Impossibile creare l'utente perchè la password è errata.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="Impossibile aggiungere l'utente al gruppo.  ([2]   [3]   [4]   [5])" />
+    <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="Impossibile concedere i 'accedere come servizio' diritti all'utente.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="Impossibile creare l'utente perchè già esistente.  ([2]   [3]   [4]   [5])" />
 
     <String Id="msierrSMBFailedCreate" Overridable="yes" Value="Impossibile creare la risorsa di rete.  ([2]   [3]   [4]   [5])" />

--- a/src/ext/Util/wixlib/ja-jp.wxl
+++ b/src/ext/Util/wixlib/ja-jp.wxl
@@ -5,6 +5,7 @@
   <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="ユーザー作成に失敗しました。  ([2]   [3]   [4]   [5])" />
   <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="パスワードが無効のためユーザー作成に失敗しました。  ([2]   [3]   [4]   [5])" />
   <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="ユーザーをグループに追加でいませんでした。  ([2]   [3]   [4]   [5])" />
+  <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="ユーザーに「サービスとしてログオン」権限を付与できませんでした。  ([2]   [3]   [4]   [5])" />
   <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="ユーザーが既に存在するため作成できませんでした。  ([2]   [3]   [4]   [5])" />
 
   <String Id="msierrSMBFailedCreate" Overridable="yes" Value="ネットワーク共有の作成に失敗しました。  ([2]   [3]   [4]   [5])" />

--- a/src/ext/Util/wixlib/lt-lt.wxl
+++ b/src/ext/Util/wixlib/lt-lt.wxl
@@ -5,6 +5,7 @@
     <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="Nepavyko sukurti vartotojo.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="Vartotojo sukurti nepavyko, nes klaidingas slaptažodis.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="Nepavyko pridėti vartotojo prie grupės.  ([2]   [3]   [4]   [5])" />
+    <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="Nepavyko suteikti vartotojui „prisijungimo kaip paslaugos“ teisių. ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="Vartotojo sukurti nepavyko, nes toks vartotojas jau egzistuoja.  ([2]   [3]   [4]   [5])" />
 
     <String Id="msierrSMBFailedCreate" Overridable="yes" Value="Nepavyko sukurti tinklo prieigos resurso.  ([2]   [3]   [4]   [5])" />

--- a/src/ext/Util/wixlib/nl-nl.wxl
+++ b/src/ext/Util/wixlib/nl-nl.wxl
@@ -5,6 +5,7 @@
     <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="De gebruiker kon niet worden aangemaakt.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="De gebruiker kon niet worden aangemaakt vanwege een ongeldig wachtwoord.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="De gebruikersgroep kon niet worden toegevoegd.  ([2]   [3]   [4]   [5])" />
+    <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="De gebruiker kon niet worden rechten verlenen 'aanmelden als service'.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="De gebruiker kon niet worden aangemaakt omdat hij al bestond.  ([2]   [3]   [4]   [5])" />
 
     <String Id="msierrSMBFailedCreate" Overridable="yes" Value="Netwerk delen kon niet worden aangemaakt.  ([2]   [3]   [4]   [5])" />

--- a/src/ext/Util/wixlib/pt-br.wxl
+++ b/src/ext/Util/wixlib/pt-br.wxl
@@ -5,20 +5,27 @@
     <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="Falha ao criar usuário. ([2] [3] [4] [5])" />
     <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="Falha ao criar usuário devido a senha inválida. ([2] [3] [4] [5])" />
     <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="Falha ao adicionar o usuário ao grupo. ([2] [3] [4] [5])" />
+    <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="Não foi possível conceder ao usuário direitos de 'fazer logon como serviço'. ([2] [3] [4] [5])" />
     <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="Falha ao criar o usuário, porque ele já existe. ([2] [3] [4] [5])" />
+
     <String Id="msierrSMBFailedCreate" Overridable="yes" Value="Falha ao criar o compartilhamento de rede. ([2] [3] [4] [5])" />
     <String Id="msierrSMBFailedDrop" Overridable="yes" Value="Falha ao cair compartilhamento de rede. ([2] [3] [4] [5])" />
+
     <String Id="msierrPERFMONFailedRegisterDLL" Overridable="yes" Value="Falha ao registrar DLL com PerfMon. ([2] [3] [4] [5])" />
     <String Id="msierrPERFMONFailedUnregisterDLL" Overridable="yes" Value="Falha ao cancelar o registro de DLL com PerfMon. ([2] [3] [4] [5])" />
+
     <String Id="msierrInstallPerfCounterData" Overridable="yes" Value="Falha ao instalar contadores de desempenho. ([2] [3] [4] [5])" />
     <String Id="msierrUninstallPerfCounterData" Overridable="yes" Value="Falha ao desinstalar contadores de desempenho. ([2] [3] [4] [5])" />
+
     <String Id="msierrSecureObjectsFailedCreateSD" Overridable="yes" Value="Falha ao criar o descritor de segurança [3] \ [4], erro do sistema: [2]" />
     <String Id="msierrSecureObjectsFailedSet" Overridable="yes" Value="Falha ao definir o descritor de segurança sobre o objeto [3], erro do sistema: [2]" />
     <String Id="msierrSecureObjectsUnknownType" Overridable="yes" Value="Objeto Desconhecido Tipo [3], erro do sistema: [2]" />
+
     <String Id="msierrXmlFileFailedRead" Overridable="yes" Value="Houve uma falha ao configurar arquivos XML." />
     <String Id="msierrXmlFileFailedOpen" Overridable="yes" Value="Falha ao abrir o arquivo XML [3], erro do sistema: [2]" />
     <String Id="msierrXmlFileFailedSelect" Overridable="yes" Value="Falha ao localizar nó: [3] no arquivo XML: [4], erro do sistema: [2]" />
     <String Id="msierrXmlFileFailedSave" Overridable="yes" Value="Falha ao salvar as alterações para o arquivo XML [3], erro do sistema: [2]" />
+
     <String Id="msierrXmlConfigFailedRead" Overridable="yes" Value="Houve uma falha ao configurar arquivos XML." />
     <String Id="msierrXmlConfigFailedOpen" Overridable="yes" Value="Falha ao abrir o arquivo XML [3], erro do sistema: [2]" />
     <String Id="msierrXmlConfigFailedSelect" Overridable="yes" Value="Falha ao localizar nó: [3] no arquivo XML: [4], erro do sistema: [2]" />

--- a/src/ext/Util/wixlib/ru-ru.wxl
+++ b/src/ext/Util/wixlib/ru-ru.wxl
@@ -5,6 +5,7 @@
     <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="Не удалось создать пользователя.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="Не удалось создать пользователя из-за неверного пароля.  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="Не удалось добавить пользователя в группу. ([2]   [3]   [4]   [5])" />
+    <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="Не удалось предоставить пользователю права входа в систему как службу. ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="Не удалось создать пользователя, поскольку он уже существует.  ([2]   [3]   [4]   [5])" />
 
     <String Id="msierrSMBFailedCreate" Overridable="yes" Value="Не удалось создать общий сетевой ресурс.  ([2]   [3]   [4]   [5])" />

--- a/src/ext/Util/wixlib/zh-cn.wxl
+++ b/src/ext/Util/wixlib/zh-cn.wxl
@@ -5,6 +5,7 @@
     <String Id="msierrUSRFailedUserCreate" Overridable="yes" Value="无法创建用户。  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreatePswd" Overridable="yes" Value="由于密码错误无法创建用户。  ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserGroupAdd" Overridable="yes" Value="无法在组中添加用户。  ([2]   [3]   [4]   [5])" />
+    <String Id="msierrUSRFailedGrantLogonAsService" Overridable="yes" Value="无法向用户授予“作为服务登录”权限。 ([2]   [3]   [4]   [5])" />
     <String Id="msierrUSRFailedUserCreateExists" Overridable="yes" Value="无法创建已经存在的用户。  ([2]   [3]   [4]   [5])" />
 
     <String Id="msierrSMBFailedCreate" Overridable="yes" Value="无法创建网络分享。  ([2]   [3]   [4]   [5])" />


### PR DESCRIPTION
Error message for failure to grant 'logon as service' rights is not currently localised.
Added translations in line with existing defined locales, Google translate used, but with some tweaking to try to keep 'log on as service' as a specific term.