### PR TITLE
Use ExePayloadRef for PrimaryPayloadId and SecondaryPayloadId

### DIFF
--- a/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/BalExtensionFixture.cs
+++ b/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/BalExtensionFixture.cs
@@ -3,10 +3,9 @@
 namespace WixToolsetTest.BootstrapperApplications
 {
     using System;
+    using System.Collections.Generic;
     using System.IO;
     using System.Linq;
-    using System.Xml;
-    using WixToolset.BootstrapperApplications;
     using WixInternal.Core.TestPackage;
     using WixInternal.TestSupport;
     using Xunit;
@@ -48,6 +47,47 @@ namespace WixToolsetTest.BootstrapperApplications
                 }, balPackageInfos);
 
                 Assert.True(File.Exists(Path.Combine(baFolderPath, "thm.wxl")));
+            }
+        }
+
+        [Fact]
+        public void CanBuildUsingBootstrapperApplicationId()
+        {
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var bundleFile = Path.Combine(baseFolder, "bin", "test.exe");
+                var bundleSourceFolder = TestData.Get("TestData", "WixStdBa");
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var baFolderPath = Path.Combine(baseFolder, "ba");
+                var extractFolderPath = Path.Combine(baseFolder, "extract");
+
+                var compileResult = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(bundleSourceFolder, "BootstrapperApplicationId.wxs"),
+                    "-ext", TestData.Get(@"WixToolset.BootstrapperApplications.wixext.dll"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-bindpath", Path.Combine(bundleSourceFolder, "data"),
+                    "-o", bundleFile,
+                });
+                compileResult.AssertSuccess();
+
+                Assert.True(File.Exists(bundleFile));
+
+                var extractResult = BundleExtractor.ExtractBAContainer(null, bundleFile, baFolderPath, extractFolderPath);
+                extractResult.AssertSuccess();
+
+                var ignoreAttributesByElementName = new Dictionary<string, List<string>>
+                {
+                    { "Payload", new List<string> { "SourcePath" } },
+                };
+
+                var wixStdBaPayloadInfo = extractResult.GetManifestTestXmlLines("/burn:BurnManifest/burn:UX/burn:Payload[@FilePath='wixstdba.exe']", ignoreAttributesByElementName);
+                WixAssert.CompareLineByLine(new string[]
+                {
+                    $@"<Payload Id='WixStandardBootstrapperApplication_X86' FilePath='wixstdba.exe' SourcePath='*' />"
+                }, wixStdBaPayloadInfo);
             }
         }
 

--- a/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/TestData/WixStdBa/BootstrapperApplicationId.wxs
+++ b/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/TestData/WixStdBa/BootstrapperApplicationId.wxs
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
+    <Bundle Name="WixStdBa" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="75D5D534-E177-4689-AAE9-CAC1C39002C2">
+        <BootstrapperApplication Id="Custom">
+            <bal:WixStandardBootstrapperApplication LicenseUrl="http://wixtoolset.org/about/license/" Theme="hyperlinkLicense" />
+        </BootstrapperApplication>
+        <Chain>
+            <MsiPackage SourceFile="test.msi" />
+        </Chain>
+    </Bundle>
+</Wix>

--- a/src/wix/WixToolset.Core.Burn/Bundles/CreateBurnManifestCommand.cs
+++ b/src/wix/WixToolset.Core.Burn/Bundles/CreateBurnManifestCommand.cs
@@ -168,11 +168,11 @@ namespace WixToolset.Core.Burn.Bundles
                 // write the UX element
                 writer.WriteStartElement("UX");
 
-                writer.WriteAttributeString("PrimaryPayloadId", this.PrimaryBundleApplicationSymbol.Id.Id);
+                writer.WriteAttributeString("PrimaryPayloadId", this.PrimaryBundleApplicationSymbol.ExePayloadRef);
 
-                if (!String.IsNullOrEmpty(this.SecondaryBundleApplicationSymbol?.Id.Id))
+                if (!String.IsNullOrEmpty(this.SecondaryBundleApplicationSymbol?.ExePayloadRef))
                 {
-                    writer.WriteAttributeString("SecondaryPayloadId", this.SecondaryBundleApplicationSymbol.Id.Id);
+                    writer.WriteAttributeString("SecondaryPayloadId", this.SecondaryBundleApplicationSymbol.ExePayloadRef);
                 }
 
                 // write the UX allPayloads...


### PR DESCRIPTION
This is a fix when using a custom BootstrapperApplication Id. This property can be anything, for example, "MyBootstrapper", but it's later assigned to `PrimaryPayloadId`, which is matched against Payload Id here:

```cpp
    // Find the primary and secondary bootstrapper application payloads.
    for (DWORD i = 0; i < pUserExperience->payloads.cPayloads; ++i)
    {
        BURN_PAYLOAD* pPayload = pUserExperience->payloads.rgPayloads + i;

        if (!pUserExperience->pPrimaryExePayload && CSTR_EQUAL == ::CompareStringOrdinal(pPayload->sczKey, -1, sczPrimaryId, -1, FALSE))
        {
            pUserExperience->pPrimaryExePayload = pPayload;
        }
        else if (fFoundSecondary && !pUserExperience->pSecondaryExePayload && CSTR_EQUAL == ::CompareStringOrdinal(pPayload->sczKey, -1, sczSecondaryId, -1, FALSE))
        {
            pUserExperience->pSecondaryExePayload = pPayload;
        }
    }
```

While ExePayloadRef is exactly the reference to the exe payload.

Fixes wixtoolset/issues#8673