### PR TITLE
Add Sandbox configuration to more easily perform Integration tests.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,3 +409,6 @@ src/test/burn/TestData/Manual/BundleB/PackagePayloads
 # Allow the projects that end in ".Cab"
 !src/dtf/test/WixToolset.Dtf.Compression.Cab
 !src/dtf/test/WixToolsetTests.Dtf.Compression.Cab
+
+#ignore the Sandbox
+src/test/sandbox/

--- a/src/test/sandbox/README
+++ b/src/test/sandbox/README
@@ -1,0 +1,2 @@
+1. Run setup_sandbox.bat from the Host, pick whether you want to use the EXE or the ZIP to install Dotnet.  The chosen option will be automatically downloaded.
+2. Once you have built Wix Toolset and wish to perform integration testing, you can just launch the Sandbox by double-clicking (or executing) TestSandbox.wsb

--- a/src/test/sandbox/TestSandbox.wsb
+++ b/src/test/sandbox/TestSandbox.wsb
@@ -1,0 +1,17 @@
+<Configuration>
+    <MappedFolders>
+        <MappedFolder>
+            <HostFolder>..\..\..\build</HostFolder>
+            <SandboxFolder>C:\build</SandboxFolder>
+            <ReadOnly>true</ReadOnly>
+        </MappedFolder>
+		<MappedFolder>
+            <HostFolder>.\</HostFolder>
+            <SandboxFolder>C:\sandbox</SandboxFolder>
+            <ReadOnly>true</ReadOnly>
+        </MappedFolder>
+    </MappedFolders>
+	<LogonCommand>
+		<Command>C:\sandbox\startup.bat</Command>
+	</LogonCommand>
+</Configuration>

--- a/src/test/sandbox/runtest_menu.bat
+++ b/src/test/sandbox/runtest_menu.bat
@@ -32,7 +32,7 @@ if not "%MsVsMonPath%"=="" (
 )
 
 REM And then for each 'runtests.cmd' file we find
-for /f %%i in ('where /R c:\build runtests.cmd') do (
+for /f %%i in ('where /R C:\build runtests.cmd') do (
   set /A "index+=1"
   echo [!index!] %%i
   set "option[!index!]=%%i!"

--- a/src/test/sandbox/runtest_menu.bat
+++ b/src/test/sandbox/runtest_menu.bat
@@ -9,11 +9,11 @@ REM to change for each invocation of the Sandbox environment
 for /f "tokens=2 delims=[]" %%a in ('ping -n 1 -4 ""') do set IPAddr=%%a
 @if %PROCESSOR_ARCHITECTURE%=="ARM64" (
 	@if exist C:\sandbox\Debugger\ARM64\msvsmon.exe (
-		set MsVsMonPath=C:\sandbox\Debugger\ARM64\msvsmon.exe
+		set "MsVsMonPath=C:\sandbox\Debugger\ARM64\msvsmon.exe /noauth /anyuser /nosecuritywarn"
 	)
 ) else (
 	@if exist C:\sandbox\Debugger\x64\msvsmon.exe (
-		set MsVsMonPath=C:\sandbox\Debugger\x64\msvsmon.exe
+		set "MsVsMonPath=C:\sandbox\Debugger\x64\msvsmon.exe /noauth /anyuser /nosecuritywarn"
 	)
 )
 
@@ -53,13 +53,13 @@ set "TestIs=!option[%SelectTest%]!"
 if not "%SelectTest%"=="0" (
 	REM for the non-Debugger options, we want to get the basepath
 	REM the file name, and a TestName component..
-	for %%a in (%TestIs%) do set FileDir=%%~dpa
-	for %%b in (%TestIs%) do set FileName=%%~nxb
+	for %%a in (%TestIs%) do set "FileDir=%%~dpa"
+	for %%b in (%TestIs%) do set "FileName=%%~nxb"
 
 	REM since we start from C:\build, the 3rd token in '\' is
 	REM the 'IntegrationMsi' naming that looks good for a TestName
 	for /f "tokens=3 delims=\" %%c in ("%TestIs%") do (
-		set TestName=%%c
+		set "TestName=%%c"
 	)
 
 	REM We just start these as a separate window

--- a/src/test/sandbox/runtest_menu.bat
+++ b/src/test/sandbox/runtest_menu.bat
@@ -1,0 +1,51 @@
+@setlocal EnableDelayedExpansion
+@echo off
+
+for /f "tokens=2 delims=[]" %%a in ('ping -n 1 -4 ""') do set IPAddr=%%a
+@if %PROCESSOR_ARCHITECTURE%=="ARM64" (
+	@if exist C:\sandbox\Debugger\ARM64\msvsmon.exe (
+		set MsVsMonPath=C:\sandbox\Debugger\ARM64\msvsmon.exe
+	)
+) else (
+	@if exist C:\sandbox\Debugger\x64\msvsmon.exe (
+		set MsVsMonPath=C:\sandbox\Debugger\x64\msvsmon.exe
+	)
+)
+
+:TestSelect
+cls
+REM Show the test select menu
+set index=0
+if not "%MsVsMonPath%"=="" (
+	echo [!index!] Run Remote Debugger SandboxIP=%IPAddr%
+	set "option[!index!]=%MsVsMonPath%"
+)
+
+for /f %%i in ('where /R c:\build runtests.cmd') do (
+  set /A "index+=1"
+  echo [!index!] %%i
+  set "option[!index!]=%%i!"
+)
+echo [q] Quit
+
+set /P "SelectTest=Please Choose The Test You Want To Execute: "
+if "%SelectTest%"=="q" Goto End
+if defined option[%SelectTest%] Goto TestSet
+
+:TestError
+cls
+Echo ERROR: Invalid Test Selected!!
+pause
+goto TestSelect
+
+:TestSet
+set "TestIs=!option[%SelectTest%]!"
+for %%a in (%TestIs%) do set FileDir=%%~dpa
+for %%a in (%TestIs%) do set FileName=%%~nxa
+start /D %FileDir% %FileName%
+if %SelectTest%==0 (
+goto TestSelect
+)
+
+:End
+@endlocal

--- a/src/test/sandbox/runtest_menu.bat
+++ b/src/test/sandbox/runtest_menu.bat
@@ -1,6 +1,11 @@
 @setlocal EnableDelayedExpansion
 @echo off
 
+REM We look to see if there's a debugger available in the injected sandbox folder
+REM from the host.  If there is, we'll show it as a launch option (later) for the
+REM user.
+REM If we do offer the debugger, we better show the IP address too, since it seems
+REM to change for each invocation of the Sandbox environment
 for /f "tokens=2 delims=[]" %%a in ('ping -n 1 -4 ""') do set IPAddr=%%a
 @if %PROCESSOR_ARCHITECTURE%=="ARM64" (
 	@if exist C:\sandbox\Debugger\ARM64\msvsmon.exe (
@@ -15,17 +20,22 @@ for /f "tokens=2 delims=[]" %%a in ('ping -n 1 -4 ""') do set IPAddr=%%a
 :TestSelect
 cls
 REM Show the test select menu
+
+REM We start with an entry for the Debugger if available
 set index=0
 if not "%MsVsMonPath%"=="" (
-	echo [!index!] Run Remote Debugger SandboxIP=%IPAddr%
+	echo [!index!] Run Remote Debugger [SandboxIP=%IPAddr%]
 	set "option[!index!]=%MsVsMonPath%"
 )
 
+REM And then for each 'runtests.cmd' file we find
 for /f %%i in ('where /R c:\build runtests.cmd') do (
   set /A "index+=1"
   echo [!index!] %%i
   set "option[!index!]=%%i!"
 )
+
+REM and finally an option to quit the menu
 echo [q] Quit
 
 set /P "SelectTest=Please Choose The Test You Want To Execute: "
@@ -40,12 +50,25 @@ goto TestSelect
 
 :TestSet
 set "TestIs=!option[%SelectTest%]!"
-for %%a in (%TestIs%) do set FileDir=%%~dpa
-for %%a in (%TestIs%) do set FileName=%%~nxa
-start /D %FileDir% %FileName%
-if %SelectTest%==0 (
-goto TestSelect
+if not "%SelectTest%"=="0" (
+	REM for the non-Debugger options, we want to get the basepath
+	REM the file name, and a TestName component..
+	for %%a in (%TestIs%) do set FileDir=%%~dpa
+	for %%b in (%TestIs%) do set FileName=%%~nxb
+
+	REM since we start from C:\build, the 3rd token in '\' is
+	REM the 'IntegrationMsi' naming that looks good for a TestName
+	for /f "tokens=3 delims=\" %%c in ("%TestIs%") do (
+		set TestName=%%c
+	)
+
+	REM We just start these as a separate window
+	REM and use cmd.exe /K to keep it around after execution has finished
+	start "!TestName!" /D "!FileDir!" cmd.exe /K !FileName!
+) else (
+	start !TestIs!
 )
+goto TestSelect
 
 :End
 @endlocal

--- a/src/test/sandbox/runtest_menu.bat
+++ b/src/test/sandbox/runtest_menu.bat
@@ -16,6 +16,9 @@ for /f "tokens=2 delims=[]" %%a in ('ping -n 1 -4 ""') do set IPAddr=%%a
 		set "MsVsMonPath=C:\sandbox\Debugger\x64\msvsmon.exe /noauth /anyuser /nosecuritywarn"
 	)
 )
+FOR /F "tokens=* USEBACKQ" %%F IN (`powershell -Command "[System.Net.Dns]::GetHostEntry('localhost').HostName"`) DO (
+SET "Hostname=%%F"
+)
 
 :TestSelect
 cls
@@ -24,7 +27,7 @@ REM Show the test select menu
 REM We start with an entry for the Debugger if available
 set index=0
 if not "%MsVsMonPath%"=="" (
-	echo [!index!] Run Remote Debugger [SandboxIP=%IPAddr%]
+	echo [!index!] Run Remote Debugger [IP=%IPAddr%] [Hostname=%Hostname%]
 	set "option[!index!]=%MsVsMonPath%"
 )
 

--- a/src/test/sandbox/runtest_menu.bat
+++ b/src/test/sandbox/runtest_menu.bat
@@ -8,12 +8,12 @@ REM If we do offer the debugger, we better show the IP address too, since it see
 REM to change for each invocation of the Sandbox environment
 for /f "tokens=2 delims=[]" %%a in ('ping -n 1 -4 ""') do set IPAddr=%%a
 @if %PROCESSOR_ARCHITECTURE%=="ARM64" (
-	@if exist C:\sandbox\Debugger\ARM64\msvsmon.exe (
-		set "MsVsMonPath=C:\sandbox\Debugger\ARM64\msvsmon.exe /noauth /anyuser /nosecuritywarn"
+	@if exist C:\sandbox\assets\Debugger\ARM64\msvsmon.exe (
+		set "MsVsMonPath=C:\sandbox\assets\Debugger\ARM64\msvsmon.exe /noauth /anyuser /nosecuritywarn"
 	)
 ) else (
-	@if exist C:\sandbox\Debugger\x64\msvsmon.exe (
-		set "MsVsMonPath=C:\sandbox\Debugger\x64\msvsmon.exe /noauth /anyuser /nosecuritywarn"
+	@if exist C:\sandbox\assets\Debugger\x64\msvsmon.exe (
+		set "MsVsMonPath=C:\sandbox\assets\Debugger\x64\msvsmon.exe /noauth /anyuser /nosecuritywarn"
 	)
 )
 FOR /F "tokens=* USEBACKQ" %%F IN (`powershell -Command "[System.Net.Dns]::GetHostEntry('localhost').HostName"`) DO (

--- a/src/test/sandbox/sandbox_registry
+++ b/src/test/sandbox/sandbox_registry
@@ -1,0 +1,21 @@
+Windows Registry Editor Version 5.00
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Policies\Microsoft\Windows\Installer]
+"Logging"="voicewarmupx"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\Windows Error Reporting\LocalDumps]
+"DumpFolder"=hex(2):43,00,3a,00,5c,00,62,00,75,00,69,00,6c,00,64,00,5c,00,6c,\
+  00,6f,00,67,00,73,00,5c,00,63,00,72,00,61,00,73,00,68,00,64,00,75,00,6d,00,\
+  70,00,73,00,00,00
+"DumpCount"=dword:0000000a
+"DumpType"=dword:00000001
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Policies\Microsoft\Windows\Installer]
+"Logging"="voicewarmupx"
+
+[HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\Windows Error Reporting\LocalDumps]
+"DumpFolder"=hex(2):43,00,3a,00,5c,00,62,00,75,00,69,00,6c,00,64,00,5c,00,6c,\
+  00,6f,00,67,00,73,00,5c,00,63,00,72,00,61,00,73,00,68,00,64,00,75,00,6d,00,\
+  70,00,73,00,00,00
+"DumpCount"=dword:0000000a
+"DumpType"=dword:00000001

--- a/src/test/sandbox/setup_sandbox.bat
+++ b/src/test/sandbox/setup_sandbox.bat
@@ -1,4 +1,4 @@
-@setlocal
+@setlocal enabledelayedexpansion
 @echo off
 SET DOTNET_VERSION=8.0
 
@@ -20,19 +20,28 @@ goto MENU
 
 :EXE
 echo EXE> dotnet.cfg
+if not exist .\assets mkdir .\assets
 if %PROCESSOR_ARCHITECTURE%=="ARM64" (
-	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.exe --output ".\dotnet-sdk.exe"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.exe --output ".\assets\dotnet-sdk-64.exe"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/windowsdesktop-runtime-win-arm64.exe --output ".\assets\windowsdesktop-runtime-64.exe"
 ) else (
-	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.exe --output ".\dotnet-sdk.exe"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.exe --output ".\assets\dotnet-sdk-64.exe"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/windowsdesktop-runtime-win-x86.exe --output ".\assets\windowsdesktop-runtime-x86.exe"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/windowsdesktop-runtime-win-x64.exe --output ".\assets\windowsdesktop-runtime-64.exe"
 )
 goto VSDEBUG
 
 :ZIP
 echo ZIP> dotnet.cfg
+if not exist .\assets mkdir .\assets
 if %PROCESSOR_ARCHITECTURE%=="ARM64" (
-	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.zip --output ".\dotnet-sdk.zip"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.zip --output ".\assets\dotnet-sdk-64.zip"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/windowsdesktop-runtime-win-arm64.zip --output ".\assets\windowsdesktop-runtime-64.zip"
 ) else (
-	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.zip --output ".\dotnet-sdk.zip"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.zip --output ".\assets\dotnet-sdk-64.zip"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/windowsdesktop-runtime-win-x64.zip --output ".\assets\windowsdesktop-runtime-64.zip"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-x86.zip --output ".\assets\dotnet-runtime-x86.zip"
+	curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/windowsdesktop-runtime-win-x86.zip --output ".\assets\windowsdesktop-runtime-x86.zip"
 )
 goto VSDEBUG
 
@@ -49,15 +58,15 @@ if not "!VsInstallDir!"=="" (
 	echo.
 	echo Have found VisualStudio Debugger at '%VsInstallDir%'
 	set /P "Confirm=Do you wish to copy it for use by the Sandbox? (Y / N):"
-	if "%Confirm%"=="Y" goto VSDEBUG_COPY
-	if "%Confirm%"=="y" goto VSDEBUG_COPY
+	if "!Confirm!"=="Y" goto VSDEBUG_COPY
+	if "!Confirm!"=="y" goto VSDEBUG_COPY
 	goto END
 )
 goto END
 
 :VSDEBUG_COPY
-if not exist Debugger (mkdir Debugger)
-XCOPY "%VsInstallDir%\Common7\IDE\Remote Debugger\*" ".\Debugger\" /E /Y > nul
+if not exist ".\assets\Debugger" (mkdir ".\assets\Debugger")
+XCOPY "%VsInstallDir%\Common7\IDE\Remote Debugger\*" ".\assets\Debugger\" /E /Y > nul
 echo Debugger files copied
 
 

--- a/src/test/sandbox/setup_sandbox.bat
+++ b/src/test/sandbox/setup_sandbox.bat
@@ -1,16 +1,36 @@
 @setlocal
-@SET DOTNET_VERSION=8.0
+@echo off
+SET DOTNET_VERSION=8.0
 
-@if not exist AMD64 (mkdir AMD64)
-@if not exist ARM64 (mkdir ARM64)
-@REM if not exist VSTest (mkdir VSTest)
+if not exist AMD64 (mkdir AMD64)
+if not exist ARM64 (mkdir ARM64)
+REM if not exist VSTest (mkdir VSTest)
 
+@echo on
 curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-x64.zip --output ".\AMD64\dotnet-runtime.zip"
 curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.zip --output ".\AMD64\dotnet-sdk.zip"
 curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-arm64.zip --output ".\ARM64\dotnet-runtime.zip"
 curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.zip --output ".\ARM64\dotnet-sdk.zip"
+@echo off
 
-REM "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease
+REM curl -L0 https://aka.ms/vs/17/release/RemoteTools.amd64ret.enu.exe --output ".\AMD64\RemoteTools.exe"
+REM curl -L0 https://aka.ms/vs/17/release/RemoteTools.arm64ret.enu.exe --output ".\ARM64\RemoteTools.exe"
+
+for /f "usebackq tokens=*" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -latest -requires Microsoft.VisualStudio.Debugger.Remote -property installationPath`) do (
+  set VsInstallDir=%%i
+)
+if "!VsInstallDir!"=="" (
+	for /f "usebackq tokens=*" %%i in (`"C:\Program Files (x86)\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease -latest -requires Microsoft.VisualStudio.Debugger.Remote -property installationPath`) do (
+	  set VsInstallDir=%%i
+	)
+)
+if "!VsInstallDir!"=="" (
+	set /P "Confirm=Have found VisualStudio Debugger at '%VsInstallDir%', Do you wish to copy it for use by the Sandbox? (Y / N):"
+	if "%Confirm%"=="Y" (
+		XCOPY "%VsInstallDir%\Common7\IDE\Remote Debugger\*" ".\Debugger\" /E
+	)
+)
 
 
+pause
 @endlocal

--- a/src/test/sandbox/setup_sandbox.bat
+++ b/src/test/sandbox/setup_sandbox.bat
@@ -24,10 +24,13 @@ if "!VsInstallDir!"=="" (
 	  set VsInstallDir=%%i
 	)
 )
-if "!VsInstallDir!"=="" (
-	set /P "Confirm=Have found VisualStudio Debugger at '%VsInstallDir%', Do you wish to copy it for use by the Sandbox? (Y / N):"
-	if "%Confirm%"=="Y" (
-		XCOPY "%VsInstallDir%\Common7\IDE\Remote Debugger\*" ".\Debugger\" /E
+if not "!VsInstallDir!"=="" (
+	echo.
+	echo Have found VisualStudio Debugger at '%VsInstallDir%'
+	set /P "Confirm=Do you wish to copy it for use by the Sandbox? (Y / N):"
+	echo Confirm = %Confirm%
+	@if "%Confirm%"=="Y" or "%Confirm%"="y" (
+		XCOPY "%VsInstallDir%\Common7\IDE\Remote Debugger\*" ".\Debugger\" /E /Y
 	)
 )
 

--- a/src/test/sandbox/setup_sandbox.bat
+++ b/src/test/sandbox/setup_sandbox.bat
@@ -7,9 +7,9 @@ if not exist ARM64 (mkdir ARM64)
 REM if not exist VSTest (mkdir VSTest)
 
 @echo on
-curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-x64.zip --output ".\AMD64\dotnet-runtime.zip"
+REM curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-x64.zip --output ".\AMD64\dotnet-runtime.zip"
 curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.zip --output ".\AMD64\dotnet-sdk.zip"
-curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-arm64.zip --output ".\ARM64\dotnet-runtime.zip"
+REM curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-arm64.zip --output ".\ARM64\dotnet-runtime.zip"
 curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.zip --output ".\ARM64\dotnet-sdk.zip"
 @echo off
 

--- a/src/test/sandbox/setup_sandbox.bat
+++ b/src/test/sandbox/setup_sandbox.bat
@@ -1,0 +1,16 @@
+@setlocal
+@SET DOTNET_VERSION=8.0
+
+@if not exist AMD64 (mkdir AMD64)
+@if not exist ARM64 (mkdir ARM64)
+@REM if not exist VSTest (mkdir VSTest)
+
+curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-x64.zip --output ".\AMD64\dotnet-runtime.zip"
+curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.zip --output ".\AMD64\dotnet-sdk.zip"
+curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-arm64.zip --output ".\ARM64\dotnet-runtime.zip"
+curl -L0 https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.zip --output ".\ARM64\dotnet-sdk.zip"
+
+REM "%ProgramFiles(x86)%\Microsoft Visual Studio\Installer\vswhere.exe" -prerelease
+
+
+@endlocal

--- a/src/test/sandbox/startup.bat
+++ b/src/test/sandbox/startup.bat
@@ -12,44 +12,45 @@ goto ERROR_NO_CONFIG
 
 :ZIP
 mkdir "%ProgramFiles%\dotnet"
-if exist %SANDBOX_FILES%\dotnet-sdk.zip (
-	tar -oxzf "%SANDBOX_FILES%\dotnet-sdk.zip" -C "%ProgramFiles%\dotnet"
+if exist %SANDBOX_FILES%\assets\dotnet-sdk-64.zip (
+	tar -oxzf "%SANDBOX_FILES%\assets\dotnet-sdk-64.zip" -C "%ProgramFiles%\dotnet"
 ) else (
-	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
-		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.zip --output dotnet-sdk.zip
-	) else (
-		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.zip --output dotnet-sdk.zip
-	)
-	if %errorlevel% NEQ 0 (
-		echo "No pre-provided dotnet sdk, and failed to download.  Confirm networking is available."
-		goto ERROR_NO_DOTNET
-	)
-	tar -oxzf dotnet-sdk.zip -C "%ProgramFiles%\dotnet"
-	del dotnet-sdk.zip
+	goto ERROR_NO_DOTNET
+)
+if exist %SANDBOX_FILES%\assets\windowsdesktop-runtime-64.zip (
+	tar -oxzf "%SANDBOX_FILES%\assets\windowsdesktop-runtime-64.zip" -C "%ProgramFiles%\dotnet"
+) else (
+	goto ERROR_NO_DOTNET
+)
+if exist %SANDBOX_FILES%\assets\dotnet-runtime-x86.zip (
+	mkdir "%ProgramFiles(x86)%\dotnet"
+	tar -oxzf "%SANDBOX_FILES%\assets\dotnet-runtime-x86.zip" -C "%ProgramFiles(x86)%\dotnet"
+)
+if exist %SANDBOX_FILES%\assets\windowsdesktop-runtime-x86.zip (
+	tar -oxzf "%SANDBOX_FILES%\assets\windowsdesktop-runtime-x86.zip" -C "%ProgramFiles(x86)%\dotnet"
 )
 goto PROCEED
 
 :EXE
-if exist %SANDBOX_FILES%\dotnet-sdk.exe (
-	"%SANDBOX_FILES%\dotnet-sdk.exe" /install /quiet /norestart
+if exist %SANDBOX_FILES%\assets\dotnet-sdk-64.exe (
+	"%SANDBOX_FILES%\assets\dotnet-sdk-64.exe" /install /quiet /norestart
 ) else (
-	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
-		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.exe --output dotnet-sdk.exe
-	) else (
-		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.exe --output dotnet-sdk.exe
-	)
-	if %errorlevel% NEQ 0 (
-		echo "No pre-provided dotnet sdk, and failed to download.  Confirm networking is available."
-		goto ERROR_NO_DOTNET
-	)
-	dotnet-sdk.exe /install /quiet /norestart
+	goto ERROR_NO_DOTNET
+)
+if exist %SANDBOX_FILES%\assets\windowsdesktop-runtime-64.exe (
+	"%SANDBOX_FILES%\assets\windowsdesktop-runtime-64.exe" /install /quiet /norestart
+) else (
+	goto ERROR_NO_DOTNET
+)
+if exist %SANDBOX_FILES%\assets\windowsdesktop-runtime-x86.exe (
+	"%SANDBOX_FILES%\assets\windowsdesktop-runtime-x86.exe" /install /quiet /norestart
 )
 goto PROCEED
 
 :PROCEED
 endlocal
-SETX PATH "%PATH%;%ProgramFiles%\dotnet" /M
-SET PATH=%PATH%;%ProgramFiles%\dotnet
+SETX PATH "%PATH%;%ProgramFiles%\dotnet;%ProgramFiles(x86)%\dotnet" /M
+SET PATH=%PATH%;%ProgramFiles%\dotnet;%ProgramFiles(x86)%\dotnet
 
 dotnet nuget locals all --clear
 dotnet help
@@ -65,6 +66,6 @@ goto END
 
 
 :ERROR_NO_DOTNET
-start "ERROR" CMD /c echo ERROR: Failed to find dotnet install, and download failed. Run setup_sandbox.bat again ^& pause
+start "ERROR" CMD /c echo ERROR: Failed to find dotnet install files. Run setup_sandbox.bat again ^& pause
 
 :END

--- a/src/test/sandbox/startup.bat
+++ b/src/test/sandbox/startup.bat
@@ -5,21 +5,21 @@ SET SANDBOX_FILES=C:\sandbox
 pushd "%TEMP%"
 
 mkdir "%ProgramFiles%\dotnet"
-@if exist %SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-runtime.zip (
-	tar -oxzf "%SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-runtime.zip" -C "%ProgramFiles%\dotnet"
-) else (
-	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
-		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-arm64.zip --output dotnet-runtime.zip
-	) else (
-		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-x64.zip --output dotnet-runtime.zip
-	)
-	if %errorlevel$ NEQ 0 (
-	echo No pre-provided dotnet runtime, and failed to download.  Confirm networking is available.
-	goto :ERROR
-	)
-	tar -oxzf dotnet-runtime.zip -C "%ProgramFiles%\dotnet"
-	del dotnet-runtime.zip
-)
+REM @if exist %SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-runtime.zip (
+REM 	tar -oxzf "%SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-runtime.zip" -C "%ProgramFiles%\dotnet"
+REM ) else (
+REM 	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
+REM 		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-arm64.zip --output dotnet-runtime.zip
+REM 	) else (
+REM 		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-x64.zip --output dotnet-runtime.zip
+REM 	)
+REM 	if %errorlevel% NEQ 0 (
+REM 	echo No pre-provided dotnet runtime, and failed to download.  Confirm networking is available.
+REM 	goto :ERROR
+REM 	)
+REM 	tar -oxzf dotnet-runtime.zip -C "%ProgramFiles%\dotnet"
+REM 	del dotnet-runtime.zip
+REM )
 
 @if exist %SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-sdk.zip (
 	tar -oxzf "%SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-sdk.zip" -C "%ProgramFiles%\dotnet"
@@ -27,9 +27,12 @@ mkdir "%ProgramFiles%\dotnet"
 	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
 		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.zip --output dotnet-sdk.zip
 	) else (
-		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.zip --output dotnet-runtime.zip
+		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.zip --output dotnet-sdk.zip
 	)
-	if %errorlevel$ NEQ 0 echo "No pre-provided dotnet sdk, and failed to download.  Confirm networking is available." goto exit
+	if %errorlevel% NEQ 0 (
+		echo "No pre-provided dotnet sdk, and failed to download.  Confirm networking is available."
+		goto ERROR
+	)
 	tar -oxzf dotnet-sdk.zip -C "%ProgramFiles%\dotnet"
 	del dotnet-sdk.zip
 )

--- a/src/test/sandbox/startup.bat
+++ b/src/test/sandbox/startup.bat
@@ -48,6 +48,7 @@ if exist %SANDBOX_FILES%\assets\windowsdesktop-runtime-x86.exe (
 goto PROCEED
 
 :PROCEED
+regedit /s "%SANDBOX_FILES%\sandbox_registry"
 endlocal
 SETX PATH "%PATH%;%ProgramFiles%\dotnet;%ProgramFiles(x86)%\dotnet" /M
 SET PATH=%PATH%;%ProgramFiles%\dotnet;%ProgramFiles(x86)%\dotnet

--- a/src/test/sandbox/startup.bat
+++ b/src/test/sandbox/startup.bat
@@ -1,0 +1,48 @@
+@setlocal
+SET DOTNET_VERSION=8.0
+SET SANDBOX_FILES=C:\sandbox
+
+pushd "%TEMP%"
+
+mkdir "%ProgramFiles%\dotnet"
+@if exist %SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-runtime.zip (
+	tar -oxzf "%SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-runtime.zip" -C "%ProgramFiles%\dotnet"
+) else (
+	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
+		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-arm64.zip --output dotnet-runtime.zip
+	) else (
+		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-x64.zip --output dotnet-runtime.zip
+	)
+	if %errorlevel$ NEQ 0 (
+	echo No pre-provided dotnet runtime, and failed to download.  Confirm networking is available.
+	goto :ERROR
+	)
+	tar -oxzf dotnet-runtime.zip -C "%ProgramFiles%\dotnet"
+	del dotnet-runtime.zip
+)
+
+@if exist %SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-sdk.zip (
+	tar -oxzf "%SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-sdk.zip" -C "%ProgramFiles%\dotnet"
+) else (
+	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
+		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.zip --output dotnet-sdk.zip
+	) else (
+		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.zip --output dotnet-runtime.zip
+	)
+	if %errorlevel$ NEQ 0 echo "No pre-provided dotnet sdk, and failed to download.  Confirm networking is available." goto exit
+	tar -oxzf dotnet-sdk.zip -C "%ProgramFiles%\dotnet"
+	del dotnet-sdk.zip
+)
+
+@endlocal
+SETX PATH "%PATH%;%ProgramFiles%\dotnet" /M
+SET PATH=%PATH%;%ProgramFiles%\dotnet
+dotnet nuget locals all --clear
+dotnet help
+
+
+:ERROR
+
+@popd
+cd c:\build
+start cmd

--- a/src/test/sandbox/startup.bat
+++ b/src/test/sandbox/startup.bat
@@ -1,28 +1,19 @@
 @setlocal
+@echo off
 SET DOTNET_VERSION=8.0
 SET SANDBOX_FILES=C:\sandbox
 
+set /p InstallMethod=<%SANDBOX_FILES%\dotnet.cfg
+
 pushd "%TEMP%"
+if "%InstallMethod%"=="EXE" goto EXE
+if "%InstallMethod%"=="ZIP" goto ZIP
+goto ERROR_NO_CONFIG
 
+:ZIP
 mkdir "%ProgramFiles%\dotnet"
-REM @if exist %SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-runtime.zip (
-REM 	tar -oxzf "%SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-runtime.zip" -C "%ProgramFiles%\dotnet"
-REM ) else (
-REM 	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
-REM 		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-arm64.zip --output dotnet-runtime.zip
-REM 	) else (
-REM 		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-runtime-win-x64.zip --output dotnet-runtime.zip
-REM 	)
-REM 	if %errorlevel% NEQ 0 (
-REM 	echo No pre-provided dotnet runtime, and failed to download.  Confirm networking is available.
-REM 	goto :ERROR
-REM 	)
-REM 	tar -oxzf dotnet-runtime.zip -C "%ProgramFiles%\dotnet"
-REM 	del dotnet-runtime.zip
-REM )
-
-@if exist %SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-sdk.zip (
-	tar -oxzf "%SANDBOX_FILES%\%PROCESSOR_ARCHITECTURE%\dotnet-sdk.zip" -C "%ProgramFiles%\dotnet"
+if exist %SANDBOX_FILES%\dotnet-sdk.zip (
+	tar -oxzf "%SANDBOX_FILES%\dotnet-sdk.zip" -C "%ProgramFiles%\dotnet"
 ) else (
 	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
 		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.zip --output dotnet-sdk.zip
@@ -31,21 +22,49 @@ REM )
 	)
 	if %errorlevel% NEQ 0 (
 		echo "No pre-provided dotnet sdk, and failed to download.  Confirm networking is available."
-		goto ERROR
+		goto ERROR_NO_DOTNET
 	)
 	tar -oxzf dotnet-sdk.zip -C "%ProgramFiles%\dotnet"
 	del dotnet-sdk.zip
 )
+goto PROCEED
 
-@endlocal
+:EXE
+if exist %SANDBOX_FILES%\dotnet-sdk.exe (
+	"%SANDBOX_FILES%\dotnet-sdk.exe" /install /quiet /norestart
+) else (
+	if %PROCESSOR_ARCHITECTURE%=="ARM64" (
+		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-arm64.exe --output dotnet-sdk.exe
+	) else (
+		curl -L https://aka.ms/dotnet/%DOTNET_VERSION%/dotnet-sdk-win-x64.exe --output dotnet-sdk.exe
+	)
+	if %errorlevel% NEQ 0 (
+		echo "No pre-provided dotnet sdk, and failed to download.  Confirm networking is available."
+		goto ERROR_NO_DOTNET
+	)
+	dotnet-sdk.exe /install /quiet /norestart
+)
+goto PROCEED
+
+:PROCEED
+endlocal
 SETX PATH "%PATH%;%ProgramFiles%\dotnet" /M
 SET PATH=%PATH%;%ProgramFiles%\dotnet
+
 dotnet nuget locals all --clear
 dotnet help
 
-
-:ERROR
-
-@popd
+popd
 cd c:\build
-start cmd /c C:\sandbox\runtest_menu.bat
+start "Menu" cmd /c C:\sandbox\runtest_menu.bat
+goto END
+
+:ERROR_NO_CONFIG
+start "ERROR" CMD /c echo ERROR: Host configuration has not been run, run setup_sandbox.bat first ^& pause
+goto END
+
+
+:ERROR_NO_DOTNET
+start "ERROR" CMD /c echo ERROR: Failed to find dotnet install, and download failed. Run setup_sandbox.bat again ^& pause
+
+:END

--- a/src/test/sandbox/startup.bat
+++ b/src/test/sandbox/startup.bat
@@ -45,4 +45,4 @@ dotnet help
 
 @popd
 cd c:\build
-start cmd
+start cmd /c C:\sandbox\runtest_menu.bat


### PR DESCRIPTION
Will automatically 'install' dotnet/dotnet sdk into sandbox at startup based on versions in 'src/test/sandbox/{AMD64,ARM64}' (dotnet-runtime.zip & dotnet-sdk.zip).
Running ./src/test/sandbox/setup_sandbox.bat will download the required files (when run on the host).
If the files aren't available, and the guest has network, it will attempt to download the files itself at startup.

Still to be done (possible future enhancements):
- [x] menu at startup to allow easy one button selection of which particular test set to run
- [ ] investigation into whether vstest.console.exe can be used to capture test execution, and possibly have the sandbox available as a test runner, so MSI tests could be run in the sandbox directly from the dev environment.