### PR TITLE
A number of minor fixes for WiX v6

### DIFF
--- a/src/burn/engine/registration.cpp
+++ b/src/burn/engine/registration.cpp
@@ -5,7 +5,6 @@
 
 // constants
 
-const LPCWSTR REGISTRY_RUN_KEY = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Run";
 const LPCWSTR REGISTRY_RUN_ONCE_KEY = L"SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\RunOnce";
 const LPCWSTR REGISTRY_BUNDLE_DISPLAY_ICON = L"DisplayIcon";
 const LPCWSTR REGISTRY_BUNDLE_DISPLAY_VERSION = L"DisplayVersion";

--- a/src/wix/WixToolset.Core/Compiler.cs
+++ b/src/wix/WixToolset.Core/Compiler.cs
@@ -1948,10 +1948,10 @@ namespace WixToolset.Core
                         signature = this.ParseComponentSearchElement(child);
                         break;
                     case "DirectorySearch":
-                        signature = this.ParseDirectorySearchElement(child, String.Empty);
+                        signature = this.ParseDirectorySearchElement(child, null);
                         break;
                     case "DirectorySearchRef":
-                        signature = this.ParseDirectorySearchRefElement(child, String.Empty);
+                        signature = this.ParseDirectorySearchRefElement(child, null);
                         break;
                     case "IniFileSearch":
                         signature = this.ParseIniFileSearchElement(child);

--- a/src/wix/WixToolset.Core/Link/AddDefaultSymbolsCommand.cs
+++ b/src/wix/WixToolset.Core/Link/AddDefaultSymbolsCommand.cs
@@ -56,8 +56,7 @@ namespace WixToolset.Core.Link
             // conjure a default major upgrade with the stdlib localization string for the
             // downgrade error message.
             var symbols = this.Sections.SelectMany(section => section.Symbols);
-            var upgradeSymbols = symbols.OfType<UpgradeSymbol>();
-            if (!upgradeSymbols.Any())
+            if (!symbols.OfType<UpgradeSymbol>().Any(us => !us.OnlyDetect))
             {
                 var packageSymbol = this.Find.EntrySection.Symbols.OfType<WixPackageSymbol>().FirstOrDefault();
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
@@ -116,6 +116,39 @@ namespace WixToolsetTest.CoreIntegration
         }
 
         [Fact]
+        public void PopulatesAppSearchTablesFromDirectorySearchInMergeModule()
+        {
+            var folder = TestData.Get(@"TestData");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msmPath = Path.Combine(baseFolder, @"bin\test.msm");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "AppSearch", "DirectorySearchInModule.wxs"),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msmPath,
+                    "-sw1079",
+                });
+
+                result.AssertSuccess();
+
+                Assert.True(File.Exists(msmPath));
+                var results = Query.QueryDatabase(msmPath, new[] { "AppSearch", "DrLocator", "IniLocator" });
+                WixAssert.CompareLineByLine(new[]
+                {
+                    "AppSearch:SYSTEM32FOLDER.7361203A_597E_4DA2_9024_27246B8446B2\tWindowsDrLocator.7361203A_597E_4DA2_9024_27246B8446B2",
+                    "DrLocator:WindowsDrLocator.7361203A_597E_4DA2_9024_27246B8446B2\t\t[WindowsFolder.7361203A_597E_4DA2_9024_27246B8446B2]System32\t",
+                }, results);
+            }
+        }
+
+        [Fact]
         public void PopulatesAppSearchTablesFromRegistrySearch()
         {
             var folder = TestData.Get(@"TestData");

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AppSearch/DirectorySearchInModule.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AppSearch/DirectorySearchInModule.wxs
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Module Id="DirectorySearchModule" Language="1033" Version="1.0.0.0"
+              Guid="{7361203A-597E-4DA2-9024-27246B8446B2}">
+        <Property Id="SYSTEM32FOLDER">
+            <DirectorySearch Id="WindowsDrLocator" Path="[WindowsFolder]System32" />
+        </Property>
+    </Module>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultMajorUpgrade/DefaultMajorUpgrade.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/DefaultMajorUpgrade/DefaultMajorUpgrade.wxs
@@ -1,12 +1,8 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Package Name="MajorUpgradeDowngradeMessage" Language="1033" Version="2.0.0" Manufacturer="Example Corporation" UpgradeCode="7ab24276-c628-43db-9e65-a184d052909b" Scope="perMachine">
-        <Feature Id="ProductFeature" Title="MsiPackageTitle">
-        </Feature>
-    </Package>
 
-    <Fragment>
-        <StandardDirectory Id="ProgramFiles6432Folder">
-            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-        </StandardDirectory>
-    </Fragment>
+        <Property Id="PRODUCT">
+            <ProductSearch UpgradeCode="{46649344-6CDF-4531-B91C-DCC088CBF6D3}" Minimum="1.0" />
+        </Property>
+    </Package>
 </Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/UpgradeFixture.cs
@@ -68,6 +68,7 @@ namespace WixToolsetTest.CoreIntegration
             WixAssert.CompareLineByLine(new[]
             {
                 "LaunchCondition:NOT WIX_DOWNGRADE_DETECTED\tA newer version of [ProductName] is already installed.",
+                "Upgrade:{46649344-6CDF-4531-B91C-DCC088CBF6D3}\t1.0\t\t\t258\t\tPRODUCT",
                 "Upgrade:{7AB24276-C628-43DB-9E65-A184D052909B}\t\t2.0.0\t1033\t1\t\tWIX_UPGRADE_DETECTED",
                 "Upgrade:{7AB24276-C628-43DB-9E65-A184D052909B}\t2.0.0\t\t1033\t2\t\tWIX_DOWNGRADE_DETECTED",
             }, results);


### PR DESCRIPTION
* Remove unused const.
* For fields, "" != null - fixes https://github.com/wixtoolset/issues/issues/8558
* Exclude detect-only Upgrades from default-feature - fixes https://github.com/wixtoolset/issues/issues/8125
