### PR TITLE
WiX v5.0.1 fixes

### DIFF
--- a/src/Directory.wixproj.targets
+++ b/src/Directory.wixproj.targets
@@ -11,7 +11,9 @@
       <DefineConstants>
         $(DefineConstants);
         SetupVersion=$(PackageVersion);
+        SetupMajorVersion=$(GitBaseVersionMajor);
         SetupMajorMinorVersion=$(GitBaseVersionMajor).$(GitBaseVersionMinor);
+        SetupMajorMinorPatchVersion=$(GitBaseVersionMajor).$(GitBaseVersionMinor).$(GitBaseVersionPatch);
         SetupDashedMajorMinorVersion=$(GitBaseVersionMajor)-$(GitBaseVersionMinor);
         SetupDashedPrerelease=$(PrereleaseSuffix)
       </DefineConstants>

--- a/src/dtf/WixToolset.Dtf.Compression.Cab/WixToolset.Dtf.Compression.Cab.csproj
+++ b/src/dtf/WixToolset.Dtf.Compression.Cab/WixToolset.Dtf.Compression.Cab.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <RootNamespace>WixToolset.Dtf.Compression.Cab</RootNamespace>
     <AssemblyName>WixToolset.Dtf.Compression.Cab</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net20</TargetFrameworks>
     <Description>Managed libraries for cabinet archive packing and unpacking</Description>
     <CreateDocumentationFile>true</CreateDocumentationFile>
   </PropertyGroup>

--- a/src/dtf/WixToolset.Dtf.Compression.Zip/WixToolset.Dtf.Compression.Zip.csproj
+++ b/src/dtf/WixToolset.Dtf.Compression.Zip/WixToolset.Dtf.Compression.Zip.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <RootNamespace>WixToolset.Dtf.Compression.Zip</RootNamespace>
     <AssemblyName>WixToolset.Dtf.Compression.Zip</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net20</TargetFrameworks>
     <Description>Managed libraries for zip archive packing and unpacking</Description>
     <CreateDocumentationFile>true</CreateDocumentationFile>
   </PropertyGroup>

--- a/src/dtf/WixToolset.Dtf.Compression/WixToolset.Dtf.Compression.csproj
+++ b/src/dtf/WixToolset.Dtf.Compression/WixToolset.Dtf.Compression.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <RootNamespace>WixToolset.Dtf.Compression</RootNamespace>
     <AssemblyName>WixToolset.Dtf.Compression</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net20</TargetFrameworks>
     <Description>Abstract base libraries for archive packing and unpacking</Description>
     <CreateDocumentationFile>true</CreateDocumentationFile>
   </PropertyGroup>

--- a/src/dtf/WixToolset.Dtf.Resources/WixToolset.Dtf.Resources.csproj
+++ b/src/dtf/WixToolset.Dtf.Resources/WixToolset.Dtf.Resources.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <RootNamespace>WixToolset.Dtf.Resources</RootNamespace>
     <AssemblyName>WixToolset.Dtf.Resources</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net20</TargetFrameworks>
     <Description>Classes for reading and writing resource data in executable files</Description>
     <CreateDocumentationFile>true</CreateDocumentationFile>
   </PropertyGroup>

--- a/src/dtf/WixToolset.Dtf.WindowsInstaller.Linq/WixToolset.Dtf.WindowsInstaller.Linq.csproj
+++ b/src/dtf/WixToolset.Dtf.WindowsInstaller.Linq/WixToolset.Dtf.WindowsInstaller.Linq.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <RootNamespace>WixToolset.Dtf.WindowsInstaller.Linq</RootNamespace>
     <AssemblyName>WixToolset.Dtf.WindowsInstaller.Linq</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net35</TargetFrameworks>
     <Description>LINQ extensions for Windows Installer classes</Description>
     <CreateDocumentationFile>true</CreateDocumentationFile>
   </PropertyGroup>

--- a/src/dtf/WixToolset.Dtf.WindowsInstaller.Package/WixToolset.Dtf.WindowsInstaller.Package.csproj
+++ b/src/dtf/WixToolset.Dtf.WindowsInstaller.Package/WixToolset.Dtf.WindowsInstaller.Package.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <RootNamespace>WixToolset.Dtf.WindowsInstaller</RootNamespace>
     <AssemblyName>WixToolset.Dtf.WindowsInstaller.Package</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net20</TargetFrameworks>
     <Description>Extended managed libraries for Windows Installer</Description>
     <CreateDocumentationFile>true</CreateDocumentationFile>
   </PropertyGroup>

--- a/src/dtf/WixToolset.Dtf.WindowsInstaller/CustomActionProxy.cs
+++ b/src/dtf/WixToolset.Dtf.WindowsInstaller/CustomActionProxy.cs
@@ -101,8 +101,13 @@ namespace WixToolset.Dtf.WindowsInstaller
                 return (int) ActionResult.Failure;
             }
 
+            string originalDirectory = null;
+
             try
             {
+                // Remember the original directory so we can restore it later.
+                originalDirectory = Environment.CurrentDirectory;
+
                 // Set the current directory to the location of the extracted files.
                 Environment.CurrentDirectory =
                     AppDomain.CurrentDomain.BaseDirectory;
@@ -141,6 +146,20 @@ namespace WixToolset.Dtf.WindowsInstaller
                 session.Log("Exception thrown by custom action:");
                 session.Log(ex.ToString());
                 return (int) ActionResult.Failure;
+            }
+            finally
+            {
+                try
+                {
+                    if (!String.IsNullOrEmpty(originalDirectory))
+                    {
+                        Environment.CurrentDirectory = originalDirectory;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    session.Log("Failed to restore current directory after running custom action: {0}", ex.Message);
+                }
             }
         }
 

--- a/src/dtf/WixToolset.Dtf.WindowsInstaller/WixToolset.Dtf.WindowsInstaller.csproj
+++ b/src/dtf/WixToolset.Dtf.WindowsInstaller/WixToolset.Dtf.WindowsInstaller.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <RootNamespace>WixToolset.Dtf.WindowsInstaller</RootNamespace>
     <AssemblyName>WixToolset.Dtf.WindowsInstaller</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net462</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net20</TargetFrameworks>
     <Description>Managed libraries for Windows Installer</Description>
     <CreateDocumentationFile>true</CreateDocumentationFile>
   </PropertyGroup>
@@ -19,7 +19,7 @@
     <None Include="WindowsInstaller.cd" />
   </ItemGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)'=='net462' ">
+  <ItemGroup Condition=" '$(TargetFramework)'=='net20' ">
     <Reference Include="System.Configuration" />
   </ItemGroup>
 </Project>

--- a/src/ext/Firewall/test/WixToolsetTest.Firewall/WixToolsetTest.Firewall.csproj
+++ b/src/ext/Firewall/test/WixToolsetTest.Firewall/WixToolsetTest.Firewall.csproj
@@ -5,8 +5,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>    
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/ext/Firewall/wixext/WixToolset.Firewall.wixext.csproj
+++ b/src/ext/Firewall/wixext/WixToolset.Firewall.wixext.csproj
@@ -8,8 +8,6 @@
     <Description>WiX Toolset Firewall Extension</Description>
     <Title>WiX Toolset Firewall Extension</Title>
     <DebugType>embedded</DebugType>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-    <GenerateTargetFrameworkAttribute>false</GenerateTargetFrameworkAttribute>    
   </PropertyGroup>
 
   <Import Project="..\..\WixExt.props" />

--- a/src/ext/Util/ca/precomp.h
+++ b/src/ext/Util/ca/precomp.h
@@ -15,7 +15,7 @@
 
 #include <msxml2.h>
 #include <Iads.h>
-#include <activeds.h> 
+#include <activeds.h>
 #include <lm.h>        // NetApi32.lib
 #include <Ntsecapi.h>
 #include <Dsgetdc.h>
@@ -50,5 +50,6 @@
 #include "scauser.h"
 #include "scasmb.h"
 #include "scasmbexec.h"
+#include "utilca.h"
 
 #include "..\..\caDecor.h"

--- a/src/ext/Util/ca/utilca.cpp
+++ b/src/ext/Util/ca/utilca.cpp
@@ -1,3 +1,59 @@
 // Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
 
 #include "precomp.h"
+
+HRESULT GetDomainFromServerName(
+    __deref_out_z LPWSTR* ppwzDomainName,
+    __in_z LPCWSTR wzServerName,
+    __in DWORD dwFlags
+    )
+{
+    HRESULT hr = S_OK;
+    DWORD er = ERROR_SUCCESS;
+    PDOMAIN_CONTROLLER_INFOW pDomainControllerInfo = NULL;
+    LPCWSTR wz = wzServerName ? wzServerName : L""; // initialize the domain to the provided server name (or empty string).
+
+    // If the server name was not empty, try to get the domain name out of it.
+    if (*wz)
+    {
+        er = ::DsGetDcNameW(NULL, wz, NULL, NULL, dwFlags, &pDomainControllerInfo);
+        if (RPC_S_SERVER_UNAVAILABLE == er)
+        {
+            // MSDN says, if we get the above error code, try again with the "DS_FORCE_REDISCOVERY" flag.
+            er = ::DsGetDcNameW(NULL, wz, NULL, NULL, dwFlags | DS_FORCE_REDISCOVERY, &pDomainControllerInfo);
+        }
+        ExitOnWin32Error(er, hr, "Could not get domain name from server name: %ls", wz);
+
+        if (pDomainControllerInfo->DomainControllerName)
+        {
+            // Skip the \\ prefix if present.
+            if ('\\' == *pDomainControllerInfo->DomainControllerName && '\\' == *(pDomainControllerInfo->DomainControllerName + 1))
+            {
+                wz = pDomainControllerInfo->DomainControllerName + 2;
+            }
+            else
+            {
+                wz = pDomainControllerInfo->DomainControllerName;
+            }
+        }
+    }
+
+LExit:
+    // Note: we overwrite the error code here as failure to contact domain controller above is not a fatal error.
+    if (wz && *wz)
+    {
+        hr = StrAllocString(ppwzDomainName, wz, 0);
+    }
+    else // return NULL the server name ended up empty.
+    {
+        ReleaseNullStr(*ppwzDomainName);
+        hr = S_OK;
+    }
+
+    if (pDomainControllerInfo)
+    {
+        ::NetApiBufferFree((LPVOID)pDomainControllerInfo);
+    }
+
+    return hr;
+}

--- a/src/ext/Util/ca/utilca.h
+++ b/src/ext/Util/ca/utilca.h
@@ -1,0 +1,8 @@
+#pragma once
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+HRESULT GetDomainFromServerName(
+    __deref_out_z LPWSTR* ppwzDomainName,
+    __in_z LPCWSTR wzServerName,
+    __in DWORD dwFlags
+    );

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -41,34 +41,34 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
     <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
     <PackageVersion Include="System.DirectoryServices" Version="4.7.0" />
     <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="4.7.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
     <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageVersion Include="System.Net.NetworkInformation" Version="4.3.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="1.6.0" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="1.8.1" />
     <PackageVersion Include="System.Security.Principal.Windows" Version="4.7.0" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.7.0" />
-    <PackageVersion Include="System.Text.Json" Version="4.6.0" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.7.1" />
+    <PackageVersion Include="System.Text.Json" Version="6.0.9" />
 
     <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="3.1.13" />
-    <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Native" Version="1.16.30" />
+    <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Native" Version="3.10.2154" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="4.7.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="NuGet.Credentials" Version="6.3.3" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.3.3" />
-    <PackageVersion Include="NuGet.Versioning" Version="6.3.3" />
+    <PackageVersion Include="NuGet.Credentials" Version="6.10.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.10.1" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.10.1" />
   </ItemGroup>
 
   <!--
     These MSBuild versions are trapped in antiquity for heat.exe.
   -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'" >
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="14.3"/>
+  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="14.3" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="15.7.179" />
@@ -79,10 +79,10 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />
     <PackageVersion Include="GitInfo" Version="2.3.0" />
 
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.3" />
-    <PackageVersion Include="xunit" Version="2.5.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
-    <PackageVersion Include="xunit.assert" Version="2.5.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="xunit" Version="2.8.1" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
+    <PackageVersion Include="xunit.assert" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.props
+++ b/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.props
@@ -5,8 +5,8 @@
   <PropertyGroup>
     <RepoRootDir Condition=" '$(RepoRootDir)' == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), .gitignore))</RepoRootDir>
   </PropertyGroup>
-  <Import Project="$(RepoRootDir)\packages\xunit.core.2.5.1\build\xunit.core.props" Condition="Exists('$(RepoRootDir)\packages\xunit.core.2.5.1\build\xunit.core.props')" />
-  <Import Project="$(RepoRootDir)\packages\xunit.runner.visualstudio.2.5.1\build\net462\xunit.runner.visualstudio.props" Condition="Exists('$(RepoRootDir)\packages\xunit.runner.visualstudio.2.5.1\build\net462\xunit.runner.visualstudio.props')" />
+  <Import Project="$(RepoRootDir)\packages\xunit.core.2.8.1\build\xunit.core.props" Condition="Exists('$(RepoRootDir)\packages\xunit.core.2.8.1\build\xunit.core.props')" />
+  <Import Project="$(RepoRootDir)\packages\xunit.runner.visualstudio.2.8.1\build\net462\xunit.runner.visualstudio.props" Condition="Exists('$(RepoRootDir)\packages\xunit.runner.visualstudio.2.8.1\build\net462\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>

--- a/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.targets
+++ b/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.targets
@@ -22,28 +22,28 @@
       <HintPath>$(RootPackagesFolder)xunit.abstractions.2.0.3\lib\netstandard2.0\xunit.abstractions.dll</HintPath>
     </Reference>
     <Reference Include="xunit.assert">
-      <HintPath>$(RootPackagesFolder)xunit.assert.2.5.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
+      <HintPath>$(RootPackagesFolder)xunit.assert.2.8.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
     <Reference Include="xunit.core">
-      <HintPath>$(RootPackagesFolder)xunit.extensibility.core.2.5.1\lib\netstandard1.1\xunit.core.dll</HintPath>
+      <HintPath>$(RootPackagesFolder)xunit.extensibility.core.2.8.1\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
     <Reference Include="xunit.execution.desktop">
-      <HintPath>$(RootPackagesFolder)xunit.extensibility.execution.2.5.1\lib\net452\xunit.execution.desktop.dll</HintPath>
+      <HintPath>$(RootPackagesFolder)xunit.extensibility.execution.2.8.1\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
 
-  <Import Project="$(RootPackagesFolder)xunit.core.2.5.1\build\xunit.core.targets" Condition="Exists('$(RootPackagesFolder)xunit.core.2.5.1\build\xunit.core.targets')" />
+  <Import Project="$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.targets" Condition="Exists('$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.5.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.5.1\build\xunit.core.props'))" />
-    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.5.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.5.1\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('$(RootPackagesFolder)xunit.runner.visualstudio.2.5.1\build\net462\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.runner.visualstudio.2.5.1\build\net462\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.props'))" />
+    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('$(RootPackagesFolder)xunit.runner.visualstudio.2.8.1\build\net462\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.runner.visualstudio.2.8.1\build\net462\xunit.runner.visualstudio.props'))" />
   </Target>
 
-  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.5.1\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x86" Condition=" '$(Platform)'!='x64' " />
-  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.5.1\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x64" Condition=" '$(Platform)'=='x64' " />
+  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.8.1\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x86" Condition=" '$(Platform)'!='x64' " />
+  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.8.1\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x64" Condition=" '$(Platform)'=='x64' " />
   <Target Name="Test">
     <!-- https://xunit.net/docs/running-tests-in-msbuild -->
     <!-- https://github.com/xunit/xunit/issues/2188 -->

--- a/src/internal/WixInternal.TestSupport.Native/packages.config
+++ b/src/internal/WixInternal.TestSupport.Native/packages.config
@@ -7,10 +7,10 @@
     when any of these versions are updated.
   -->
   <package id="xunit.abstractions" version="2.0.3" />
-  <package id="xunit.assert" version="2.5.1" />
-  <package id="xunit.core" version="2.5.1" />
-  <package id="xunit.extensibility.core" version="2.5.1" />
-  <package id="xunit.extensibility.execution" version="2.5.1" />
-  <package id="xunit.runner.msbuild" version="2.5.1" />
-  <package id="xunit.runner.visualstudio" version="2.5.1" />
+  <package id="xunit.assert" version="2.8.1" />
+  <package id="xunit.core" version="2.8.1" />
+  <package id="xunit.extensibility.core" version="2.8.1" />
+  <package id="xunit.extensibility.execution" version="2.8.1" />
+  <package id="xunit.runner.msbuild" version="2.8.1" />
+  <package id="xunit.runner.visualstudio" version="2.8.1" />
 </packages>

--- a/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/thmutil.cpp
@@ -312,13 +312,14 @@ static HRESULT ShowControl(
     __in BOOL fSaveEditboxes,
     __in THEME_SHOW_PAGE_REASON reason,
     __in DWORD dwPageId,
-    __out_opt HWND* phwndFocus
+    __inout_opt HWND* phwndFocus
     );
 static HRESULT ShowControls(
     __in THEME* pTheme,
     __in_opt const THEME_CONTROL* pParentControl,
     __in int nCmdShow,
     __in BOOL fSaveEditboxes,
+    __in BOOL fSetFocus,
     __in THEME_SHOW_PAGE_REASON reason,
     __in DWORD dwPageId
     );
@@ -1192,8 +1193,9 @@ DAPI_(HRESULT) ThemeShowPageEx(
     BOOL fHide = SW_HIDE == nCmdShow;
     BOOL fSaveEditboxes = FALSE;
     THEME_SAVEDVARIABLE* pSavedVariable = NULL;
-    THEME_PAGE* pPage = ThemeGetPage(pTheme, dwPage);
     SIZE_T cb = 0;
+    BOOL fSetFocus = dwPage != pTheme->dwCurrentPageId;
+    THEME_PAGE* pPage = ThemeGetPage(pTheme, dwPage);
 
     if (pPage)
     {
@@ -1257,7 +1259,7 @@ DAPI_(HRESULT) ThemeShowPageEx(
         }
     }
 
-    hr = ShowControls(pTheme, NULL, nCmdShow, fSaveEditboxes, reason, dwPage);
+    hr = ShowControls(pTheme, NULL, nCmdShow, fSaveEditboxes, fSetFocus, reason, dwPage);
     ThmExitOnFailure(hr, "Failed to show page controls.");
 
 LExit:
@@ -5561,7 +5563,7 @@ static HRESULT ShowControl(
     __in BOOL fSaveEditboxes,
     __in THEME_SHOW_PAGE_REASON reason,
     __in DWORD dwPageId,
-    __out_opt HWND* phwndFocus
+    __inout_opt HWND* phwndFocus
     )
 {
     HRESULT hr = S_OK;
@@ -5810,7 +5812,7 @@ static HRESULT ShowControl(
 
     if (0 < pControl->cControls)
     {
-        ShowControls(pTheme, pControl, nCmdShow, fSaveEditboxes, reason, dwPageId);
+        ShowControls(pTheme, pControl, nCmdShow, fSaveEditboxes, FALSE/*fSetFocus*/, reason, dwPageId);
     }
 
     if (THEME_CONTROL_TYPE_BILLBOARD == pControl->type && pControl->wPageId)
@@ -5842,6 +5844,7 @@ static HRESULT ShowControls(
     __in_opt const THEME_CONTROL* pParentControl,
     __in int nCmdShow,
     __in BOOL fSaveEditboxes,
+    __in BOOL fSetFocus,
     __in THEME_SHOW_PAGE_REASON reason,
     __in DWORD dwPageId
     )
@@ -5865,7 +5868,7 @@ static HRESULT ShowControls(
         }
     }
 
-    if (hwndFocus)
+    if (fSetFocus && hwndFocus)
     {
         ::SendMessage(pTheme->hwndParent, WM_NEXTDLGCTL, (WPARAM)hwndFocus, TRUE);
     }

--- a/src/setup/MetadataTask/GenerateMetadata.cs
+++ b/src/setup/MetadataTask/GenerateMetadata.cs
@@ -19,7 +19,7 @@ namespace WixToolset.Tasks
         private static readonly JsonSerializerOptions SerializerOptions = new JsonSerializerOptions
         {
             PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
-            IgnoreNullValues = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
             WriteIndented = true,
             Converters = { new JsonStringEnumConverter(JsonNamingPolicy.CamelCase) },
         };

--- a/src/setup/setup.cmd
+++ b/src/setup/setup.cmd
@@ -35,7 +35,9 @@ msbuild -Restore setup.sln -p:Configuration=%_C% -tl -nologo -m -warnaserror -bl
 
 :clean
 @rd /s/q "..\..\build\setup" 2> nul
+@del "..\..\build\artifacts\wix-cli-x64.*" 2> nul
 @del "..\..\build\artifacts\WixAdditionalTools.*" 2> nul
+@del "..\..\build\logs\pdbs\%_C%\wix-cli-x64.*" 2> nul
 @del "..\..\build\logs\pdbs\%_C%\WixAdditionalTools.*" 2> nul
 @exit /b
 

--- a/src/setup/setup.sln
+++ b/src/setup/setup.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "ThmViewerPackage", "ThmViewerPackage\ThmViewerPackage.wixproj", "{F8C12838-DEC5-4CA5-97A8-DFE2247564C5}"
 EndProject
+Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "wix-cli", "wix-cli\wix-cli.wixproj", "{69C043AF-F9D4-427D-A954-D0362DF25E6E}"
+EndProject
 Project("{B7DD6F7E-DEF8-4E67-B5B7-07EF123DB6F0}") = "WixAdditionalTools", "WixAdditionalTools\WixAdditionalTools.wixproj", "{59FF3AD3-339A-4048-9F0B-504EE74BC4AF}"
 EndProject
 Global
@@ -17,6 +19,10 @@ Global
 		{F8C12838-DEC5-4CA5-97A8-DFE2247564C5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{F8C12838-DEC5-4CA5-97A8-DFE2247564C5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{F8C12838-DEC5-4CA5-97A8-DFE2247564C5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{69C043AF-F9D4-427D-A954-D0362DF25E6E}.Debug|Any CPU.ActiveCfg = Debug|x64
+		{69C043AF-F9D4-427D-A954-D0362DF25E6E}.Debug|Any CPU.Build.0 = Debug|x64
+		{69C043AF-F9D4-427D-A954-D0362DF25E6E}.Release|Any CPU.ActiveCfg = Release|x64
+		{69C043AF-F9D4-427D-A954-D0362DF25E6E}.Release|Any CPU.Build.0 = Release|x64
 		{59FF3AD3-339A-4048-9F0B-504EE74BC4AF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{59FF3AD3-339A-4048-9F0B-504EE74BC4AF}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{59FF3AD3-339A-4048-9F0B-504EE74BC4AF}.Release|Any CPU.ActiveCfg = Release|Any CPU

--- a/src/setup/wix-cli/Package.wxs
+++ b/src/setup/wix-cli/Package.wxs
@@ -1,0 +1,81 @@
+﻿<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="WiX Toolset Command-Line Tools" Manufacturer="WiX Toolset" Version="!(bind.fileVersion.WixExe)" UpgradeCode="2e85dc76-769f-46d2-82a7-46cb3a0c9d50">
+    <MediaTemplate EmbedCab="yes" />
+
+    <ComponentGroupRef Id="BinaryFiles" />
+    <ComponentGroupRef Id="ExtensionFiles" />
+
+    <Property Id="ARPURLINFOABOUT" Value="https://wixtoolset.org/" />
+    <Property Id="ARPHELPLINK" Value="https://wixtoolset.org/docs/gethelp/" />
+    <SetProperty Id="ARPINSTALLLOCATION" Value="[INSTALLFOLDER]" After="CostFinalize" />
+  </Package>
+
+  <Fragment>
+    <ComponentGroup Id="BinaryFiles" Directory="BinFolder">
+      <Component>
+        <File Id="WixExe" Source="!(bindpath.Files)\wix.exe" />
+        <File Source="!(bindpath.Files)\wix.exe.config" />
+
+        <Environment Name="PATH" Value="[BinFolder]" Action="set" Part ="last" System="yes" />
+        <Environment Name="WIX$(SetupMajorVersion)" Value="[BinFolder]" Action="set" System="yes" />
+      </Component>
+
+      <Files Include="!(bindpath.Files)\**">
+        <Exclude Files="!(bindpath.Files)\wix.exe*" />
+        <Exclude Files="!(bindpath.Files)\**\*.xml" />
+        <Exclude Files="!(bindpath.Files)\**\*.targets" />
+      </Files>
+
+      <Files Include="!(bindpath.Heat_x64)\**" Subdirectory="x64" />
+      <Files Include="!(bindpath.Heat_x86)\**" Subdirectory="x86" />
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ExtensionFiles" Directory="ExtensionFolder">
+      <File Subdirectory="WixToolset.BootstrapperApplications.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.BootstrapperApplications.wixext.dll" />
+      <File Subdirectory="WixToolset.ComPlus.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.ComPlus.wixext.dll" />
+      <File Subdirectory="WixToolset.Dependency.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.Dependency.wixext.dll" />
+      <File Subdirectory="WixToolset.DirectX.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.DirectX.wixext.dll" />
+      <File Subdirectory="WixToolset.Firewall.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.Firewall.wixext.dll" />
+      <File Subdirectory="WixToolset.Http.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.Http.wixext.dll" />
+      <File Subdirectory="WixToolset.Iis.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.Iis.wixext.dll" />
+      <File Subdirectory="WixToolset.Msmq.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.Msmq.wixext.dll" />
+      <File Subdirectory="WixToolset.NetFx.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.NetFx.wixext.dll" />
+      <File Subdirectory="WixToolset.PowerShell.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.PowerShell.wixext.dll" />
+      <File Subdirectory="WixToolset.Sql.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.Sql.wixext.dll" />
+      <File Subdirectory="WixToolset.UI.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.UI.wixext.dll" />
+      <File Subdirectory="WixToolset.Util.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.Util.wixext.dll" />
+      <File Subdirectory="WixToolset.VisualStudio.wixext\$(SetupMajorMinorPatchVersion)\wixext$(SetupMajorVersion)"
+            Source="WixToolset.VisualStudio.wixext.dll" />
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <StandardDirectory Id="ProgramFiles64Folder">
+      <Directory Id="INSTALLFOLDER" Name="WiX Toolset v$(SetupMajorMinorVersion)">
+        <Directory Id="BinFolder" Name="bin" />
+      </Directory>
+    </StandardDirectory>
+  </Fragment>
+
+  <Fragment>
+    <StandardDirectory Id="CommonFiles64Folder">
+      <Directory Id="ExtensionFolder" Name="WixToolset\extensions" />
+    </StandardDirectory>
+  </Fragment>
+</Wix>

--- a/src/setup/wix-cli/wix-cli.wixproj
+++ b/src/setup/wix-cli/wix-cli.wixproj
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project Sdk="WixToolset.Sdk">
+  <PropertyGroup>
+    <Platform>x64</Platform>
+    <OutputName>wix-cli-$(Platform)</OutputName>
+    <OutputPath>$(PackageOutputPath)</OutputPath>
+    <SignOutput>true</SignOutput>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <BindPath BindName="Files" Include="$(RootBuildFolder)wix\$(Configuration)\net472\win-$(Platform)" />
+    <BindPath BindName="Heat_x64" Include="$(RootBuildFolder)tools\$(Configuration)\net472\win-x64\" />
+    <BindPath BindName="Heat_x86" Include="$(RootBuildFolder)tools\$(Configuration)\net472\win-x86\" />
+
+    <BindPath Include="$(RootBuildFolder)Bal.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)ComPlus.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)Dependency.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)DirectX.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)Firewall.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)Http.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)Iis.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)Msmq.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)NetFx.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)PowerShell.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)Sql.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)UI.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)Util.wixext\$(Configuration)\netstandard2.0\" />
+    <BindPath Include="$(RootBuildFolder)VisualStudio.wixext\$(Configuration)\netstandard2.0\" />
+  </ItemGroup>
+
+  <UsingTask TaskName="GenerateMetadata" AssemblyFile="$(BaseOutputPath)$(Configuration)\net472\MetadataTask.dll" />
+
+  <Target Name="GenerateMetadata" AfterTargets="AfterBuild">
+    <GenerateMetadata TargetFile="$(TargetPath)" WixpdbFile="$(TargetPdbPath)" />
+  </Target>
+</Project>

--- a/src/wix/WixToolset.Core/CommandLine/CommandLine.cs
+++ b/src/wix/WixToolset.Core/CommandLine/CommandLine.cs
@@ -56,7 +56,7 @@ namespace WixToolset.Core.CommandLine
             if (!this.SuppressLogo && command?.ShowLogo == true)
             {
                 var branding = this.ServiceProvider.GetService<IWixBranding>();
-                Console.WriteLine(branding.ReplacePlaceholders("[AssemblyProduct] [AssemblyDescription] version [ProductVersion]"));
+                Console.WriteLine(branding.ReplacePlaceholders("[AssemblyProduct] version [ProductVersion]"));
                 Console.WriteLine(branding.ReplacePlaceholders("[AssemblyCopyright]"));
                 Console.WriteLine();
             }

--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -2504,8 +2504,8 @@ namespace WixToolset.Core
                 var exitSequence = CompilerConstants.IntegerNotSet;
                 var sequence = CompilerConstants.IntegerNotSet;
                 var showDialog = "Show" == actionName;
-                var specialAction = "InstallExecute" == actionName || "InstallExecuteAgain" == actionName || "RemoveExistingProducts" == actionName || "DisableRollback" == actionName || "ScheduleReboot" == actionName || "ForceReboot" == actionName || "ResolveSource" == actionName;
-                var specialStandardAction = "AppSearch" == actionName || "CCPSearch" == actionName || "RMCCPSearch" == actionName || "LaunchConditions" == actionName || "FindRelatedProducts" == actionName;
+                var specialAction = "InstallExecute" == actionName || "InstallExecuteAgain" == actionName || "RemoveExistingProducts" == actionName || "DisableRollback" == actionName || "ScheduleReboot" == actionName || "ForceReboot" == actionName || "ResolveSource" == actionName; // these actions do NOT have default sequence numbers and MUST be scheduled.
+                var specialStandardAction = "AppSearch" == actionName || "CCPSearch" == actionName || "RMCCPSearch" == actionName || "LaunchConditions" == actionName || "FindRelatedProducts" == actionName; // these standard actions have default sequence numbers so they do NOT have to be scheduled.
                 var suppress = false;
 
                 foreach (var attrib in child.Attributes())
@@ -2608,6 +2608,8 @@ namespace WixToolset.Core
                     }
                 }
 
+                var standardAction = WindowsInstallerStandard.IsStandardAction(actionName);
+
                 if (customAction && "Custom" == actionName)
                 {
                     this.Core.Write(ErrorMessages.ExpectedAttribute(childSourceLineNumbers, child.Name.LocalName, "Action"));
@@ -2653,7 +2655,7 @@ namespace WixToolset.Core
                 }
 
                 // normal standard actions cannot be set overridable by the user (since they are overridable by default)
-                if (overridable && WindowsInstallerStandard.IsStandardAction(actionName) && !specialAction)
+                if (overridable && standardAction && !specialAction)
                 {
                     this.Core.Write(ErrorMessages.UnexpectedAttribute(childSourceLineNumbers, child.Name.LocalName, "Overridable"));
                 }
@@ -2687,6 +2689,10 @@ namespace WixToolset.Core
                         else if (actionIdentifier != null)
                         {
                             access = actionIdentifier.Access;
+                        }
+                        else if (standardAction)
+                        {
+                            access = AccessModifier.Override;
                         }
 
                         var symbol = this.Core.AddSymbol(new WixActionSymbol(childSourceLineNumbers, new Identifier(access, sequenceTable, actionName))

--- a/src/wix/WixToolset.Core/Link/ProcessConflictingSymbolsCommand.cs
+++ b/src/wix/WixToolset.Core/Link/ProcessConflictingSymbolsCommand.cs
@@ -131,9 +131,16 @@ namespace WixToolset.Core.Link
             // Ensure referenced override symbols actually overrode a virtual symbol.
             foreach (var referencedOverrideSymbol in this.OverrideSymbols.Where(s => this.ResolvedSections.Contains(s.Section)))
             {
+                // The easiest check is to see if the symbol overrode a virtual symbol. If not, check to see if there were any possible
+                // virtual symbols that could have been overridden. If not, then we have an error.
                 if (referencedOverrideSymbol.Overrides is null)
                 {
-                    this.Messaging.Write(LinkerErrors.VirtualSymbolNotFoundForOverride(referencedOverrideSymbol.Symbol));
+                    var otherVirtualsCount = referencedOverrideSymbol.PossiblyConflicts.Count(s => s.Access == AccessModifier.Virtual);
+
+                    if (otherVirtualsCount == 0)
+                    {
+                        this.Messaging.Write(LinkerErrors.VirtualSymbolNotFoundForOverride(referencedOverrideSymbol.Symbol));
+                    }
                 }
             }
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/StandardActionFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/StandardActionFixture.cs
@@ -1,0 +1,124 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using System.Linq;
+    using WixInternal.Core.TestPackage;
+    using WixInternal.TestSupport;
+    using Xunit;
+
+    public class StandardActionFixture
+    {
+        [Fact]
+        public void CanCompileSpecialActionWithOverride()
+        {
+            using var fs = new DisposableFileSystem();
+
+            var results = BuildAndQueryMsi(fs, "SpecialActionOverride.wxs");
+
+            WixAssert.CompareLineByLine(new[]
+            {
+                "InstallExecuteSequence:AppSearch\t\t99",
+                "InstallExecuteSequence:CostFinalize\t\t1000",
+                "InstallExecuteSequence:CostInitialize\t\t800",
+                "InstallExecuteSequence:CreateFolders\t\t3700",
+                "InstallExecuteSequence:FileCost\t\t900",
+                "InstallExecuteSequence:FindRelatedProducts\t\t98",
+                "InstallExecuteSequence:InstallFiles\t\t4000",
+                "InstallExecuteSequence:InstallFinalize\t\t6600",
+                "InstallExecuteSequence:InstallInitialize\t\t1500",
+                "InstallExecuteSequence:InstallValidate\t\t1400",
+                "InstallExecuteSequence:LaunchConditions\t\t100",
+                "InstallExecuteSequence:MigrateFeatureStates\t\t1200",
+                "InstallExecuteSequence:ProcessComponents\t\t1600",
+                "InstallExecuteSequence:PublishFeatures\t\t6300",
+                "InstallExecuteSequence:PublishProduct\t\t6400",
+                "InstallExecuteSequence:RegisterProduct\t\t6100",
+                "InstallExecuteSequence:RegisterUser\t\t6000",
+                "InstallExecuteSequence:RemoveExistingProducts\t\t1401",
+                "InstallExecuteSequence:RemoveFiles\t\t3500",
+                "InstallExecuteSequence:RemoveFolders\t\t3600",
+                "InstallExecuteSequence:UnpublishFeatures\t\t1800",
+                "InstallExecuteSequence:ValidateProductID\t\t700",
+                "InstallUISequence:CostFinalize\t\t1000",
+                "InstallUISequence:CostInitialize\t\t800",
+                "InstallUISequence:ExecuteAction\t\t1300",
+                "InstallUISequence:FileCost\t\t900",
+                "InstallUISequence:FindRelatedProducts\t\t25",
+                "InstallUISequence:LaunchConditions\t\t100",
+                "InstallUISequence:MigrateFeatureStates\t\t1200",
+                "InstallUISequence:ValidateProductID\t\t700",
+            }, results);
+        }
+
+        [Fact]
+        public void CanCompileStandardActionWithOverride()
+        {
+            using var fs = new DisposableFileSystem();
+
+            var results = BuildAndQueryMsi(fs, "StandardActionOverride.wxs");
+
+            WixAssert.CompareLineByLine(new[]
+            {
+                "InstallExecuteSequence:CostFinalize\t\t1000",
+                "InstallExecuteSequence:CostInitialize\t\t800",
+                "InstallExecuteSequence:CreateFolders\t\t3700",
+                "InstallExecuteSequence:FileCost\t\t900",
+                "InstallExecuteSequence:FindRelatedProducts\t\t25",
+                "InstallExecuteSequence:InstallFiles\tTEST_CONDITION\t4000",
+                "InstallExecuteSequence:InstallFinalize\t\t6600",
+                "InstallExecuteSequence:InstallInitialize\t\t1500",
+                "InstallExecuteSequence:InstallValidate\t\t1400",
+                "InstallExecuteSequence:LaunchConditions\t\t100",
+                "InstallExecuteSequence:MigrateFeatureStates\t\t1200",
+                "InstallExecuteSequence:ProcessComponents\t\t1600",
+                "InstallExecuteSequence:PublishFeatures\t\t6300",
+                "InstallExecuteSequence:PublishProduct\t\t6400",
+                "InstallExecuteSequence:RegisterProduct\t\t6100",
+                "InstallExecuteSequence:RegisterUser\t\t6000",
+                "InstallExecuteSequence:RemoveExistingProducts\t\t1401",
+                "InstallExecuteSequence:RemoveFiles\t\t3500",
+                "InstallExecuteSequence:RemoveFolders\t\t3600",
+                "InstallExecuteSequence:UnpublishFeatures\t\t1800",
+                "InstallExecuteSequence:ValidateProductID\t\t700",
+                "InstallUISequence:CostFinalize\t\t1000",
+                "InstallUISequence:CostInitialize\t\t800",
+                "InstallUISequence:ExecuteAction\t\t1300",
+                "InstallUISequence:FileCost\t\t900",
+                "InstallUISequence:FindRelatedProducts\t\t25",
+                "InstallUISequence:LaunchConditions\t\t100",
+                "InstallUISequence:MigrateFeatureStates\t\t1200",
+                "InstallUISequence:ValidateProductID\t\t700",
+            }, results);
+        }
+
+        private static string[] BuildAndQueryMsi(DisposableFileSystem fs, string sourceFile)
+        {
+            var folder = TestData.Get(@"TestData");
+
+            var baseFolder = fs.GetFolder();
+            var intermediateFolder = Path.Combine(baseFolder, "obj");
+            var msiPath = Path.Combine(baseFolder, "bin", "test.msi");
+
+            var result = WixRunner.Execute(new[]
+            {
+                    "build",
+                    Path.Combine(folder, "StandardAction", sourceFile),
+                    "-bindpath", Path.Combine(folder, "SingleFile", "data"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+            result.AssertSuccess();
+
+            var results = Query.QueryDatabase(msiPath, new[]
+            {
+                "InstallExecuteSequence",
+                "InstallUISequence"
+            }).ToArray();
+
+            return results;
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/StandardAction/SpecialActionOverride.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/StandardAction/SpecialActionOverride.wxs
@@ -1,0 +1,11 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="~SpecialActionOverride" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a"
+             Compressed="no">
+        <File Source="test.txt" />
+
+        <InstallExecuteSequence>
+            <FindRelatedProducts Before="LaunchConditions" />
+            <AppSearch After="FindRelatedProducts" />
+        </InstallExecuteSequence>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/StandardAction/StandardActionOverride.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/StandardAction/StandardActionOverride.wxs
@@ -1,0 +1,10 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="~StandardActionOverride" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a"
+             Compressed="no">
+        <File Source="test.txt" />
+
+        <InstallExecuteSequence>
+            <InstallFiles Condition="TEST_CONDITION" />
+        </InstallExecuteSequence>
+    </Package>
+</Wix>


### PR DESCRIPTION
* Scheduling standard actions must override virtual definitions from stdlib - fixes wixtoolset/issues#8115
* Prevent unnecessary refreshes that move focus. - fixes wixtoolset/issues#8144
* Update dependencies - fixes wixtoolset/issues#8569
* Introducing wix-cli.msi - fixes wixtoolset/issues#8623
* Fix missing WixToolset.Firewall.wixext version - fixes wixtoolset/issues#8624

* Move DTF back to .NET 2.0 as it is still supported - fixes wixtoolset/issues#8134
* Reset current directory so SFXCA directory can be cleaned up - fixes wixtoolset/issues#8630
* Fix "wix extension list" to correctly display machine-wide extensions- fixes wixtoolset/issues#8625
* Fix faulty memory access in Util's User custom actions - fixes wixtoolset/issues#8576
