### PR TITLE
Net8, and a bunch of other dependency updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This repository contains the WiX Toolset codebase.
 
 | Individual components |
 | :-------------------- |
-| .NET 6.0 Runtime (Long Term Support) |
+| .NET 8.0 Runtime (Long Term Support) |
 | .NET Framework 4.7.2 SDK |
 | .NET Framework 4.7.2 targeting pack |
 | .NET Framework 4.6.2 targeting pack |

--- a/src/api/api.cmd
+++ b/src/api/api.cmd
@@ -27,8 +27,8 @@ msbuild api_t.proj -p:Configuration=%_C% -tl -nologo -warnaserror -bl:%_L%\api_b
 
 :: Test
 dotnet test ^
- %_B%\net6.0\WixToolsetTest.Data.dll ^
- %_B%\net6.0\win-x86\WixToolsetTest.BootstrapperApplicationApi.dll ^
+ %_B%\net8.0\WixToolsetTest.Data.dll ^
+ %_B%\net8.0\win-x86\WixToolsetTest.BootstrapperApplicationApi.dll ^
  %_B%\x86\BalUtilUnitTest.dll ^
  %_B%\x86\BextUtilUnitTest.dll ^
  --nologo -l "trx;LogFileName=%_L%\TestResults\api.trx" || exit /b

--- a/src/api/burn/test/WixToolsetTest.BootstrapperApplicationApi/WixToolsetTest.BootstrapperApplicationApi.csproj
+++ b/src/api/burn/test/WixToolsetTest.BootstrapperApplicationApi/WixToolsetTest.BootstrapperApplicationApi.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x86</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <IsWixTestProject>true</IsWixTestProject>

--- a/src/api/wix/test/WixToolsetTest.Data/WixToolsetTest.Data.csproj
+++ b/src/api/wix/test/WixToolsetTest.Data/WixToolsetTest.Data.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Bal/bal.cmd
+++ b/src/ext/Bal/bal.cmd
@@ -31,7 +31,7 @@ msbuild bal_t.proj -p:Configuration=%_C% -tl -nologo -warnaserror -bl:%_L%\bal_b
 :: Test
 dotnet test ^
   %_B%\x86\WixStdFnUnitTest.dll ^
-  %_B%\net6.0\WixToolsetTest.BootstrapperApplications.dll ^
+  %_B%\net8.0\WixToolsetTest.BootstrapperApplications.dll ^
   --nologo -l "trx;LogFileName=%_L%\TestResults\bal.wixext.trx" || exit /b
 
 @goto :end

--- a/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/WixToolsetTest.BootstrapperApplications.csproj
+++ b/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/WixToolsetTest.BootstrapperApplications.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Bal/test/examples/EarliestCoreMBA/Example.EarliestCoreMBA.csproj
+++ b/src/ext/Bal/test/examples/EarliestCoreMBA/Example.EarliestCoreMBA.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
     <OutputType>WinExe</OutputType>
     <DebugType>embedded</DebugType>

--- a/src/ext/Bal/test/examples/LatestCoreMBA/Example.LatestCoreMBA.csproj
+++ b/src/ext/Bal/test/examples/LatestCoreMBA/Example.LatestCoreMBA.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
     <OutputType>WinExe</OutputType>
     <DebugType>embedded</DebugType>

--- a/src/ext/Bal/test/examples/WPFCoreMBA/Example.WPFCoreMBA.csproj
+++ b/src/ext/Bal/test/examples/WPFCoreMBA/Example.WPFCoreMBA.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
     <Description>WPF .NET Core MBA</Description>
     <UseWPF>true</UseWPF>

--- a/src/ext/Bal/wixext-backward-compatible/WixToolset.Bal.wixext.csproj
+++ b/src/ext/Bal/wixext-backward-compatible/WixToolset.Bal.wixext.csproj
@@ -5,7 +5,7 @@
   <Import Project="..\..\WixExt.props" />
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Title>WiX Toolset BootstrapperApplications extension</Title>
     <Description>WiX Toolset BootstrapperApplications extension</Description>

--- a/src/ext/ComPlus/test/WixToolsetTest.ComPlus/WixToolsetTest.ComPlus.csproj
+++ b/src/ext/ComPlus/test/WixToolsetTest.ComPlus/WixToolsetTest.ComPlus.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Dependency/test/WixToolsetTest.Dependency/WixToolsetTest.Dependency.csproj
+++ b/src/ext/Dependency/test/WixToolsetTest.Dependency/WixToolsetTest.Dependency.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/DirectX/test/WixToolsetTest.DirectX/WixToolsetTest.DirectX.csproj
+++ b/src/ext/DirectX/test/WixToolsetTest.DirectX/WixToolsetTest.DirectX.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Firewall/test/WixToolsetTest.Firewall/WixToolsetTest.Firewall.csproj
+++ b/src/ext/Firewall/test/WixToolsetTest.Firewall/WixToolsetTest.Firewall.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Http/test/WixToolsetTest.Http/WixToolsetTest.Http.csproj
+++ b/src/ext/Http/test/WixToolsetTest.Http/WixToolsetTest.Http.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Iis/test/WixToolsetTest.Iis/WixToolsetTest.Iis.csproj
+++ b/src/ext/Iis/test/WixToolsetTest.Iis/WixToolsetTest.Iis.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Msmq/test/WixToolsetTest.Msmq/WixToolsetTest.Msmq.csproj
+++ b/src/ext/Msmq/test/WixToolsetTest.Msmq/WixToolsetTest.Msmq.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/NetFx/netcoresearch/netcoresearch.vcxproj
+++ b/src/ext/NetFx/netcoresearch/netcoresearch.vcxproj
@@ -42,8 +42,8 @@
   <PropertyGroup>
     <NetHostPlatform>$(Platform)</NetHostPlatform>
     <NetHostPlatform Condition=" '$(NetHostPlatform)'=='Win32' ">x86</NetHostPlatform>
-    <NetHostPath>..\..\..\..\packages\runtime.win-$(NetHostPlatform).Microsoft.NETCore.DotNetAppHost.6.0.4\runtimes\win-$(NetHostPlatform)\native\</NetHostPath>
-    <HostfxrPath>..\..\..\..\packages\runtime.win-$(NetHostPlatform).Microsoft.NETCore.DotNetHostResolver.6.0.4\runtimes\win-$(NetHostPlatform)\native\</HostfxrPath>
+    <NetHostPath>..\..\..\..\packages\runtime.win-$(NetHostPlatform).Microsoft.NETCore.DotNetAppHost.8.0.7\runtimes\win-$(NetHostPlatform)\native\</NetHostPath>
+    <HostfxrPath>..\..\..\..\packages\runtime.win-$(NetHostPlatform).Microsoft.NETCore.DotNetHostResolver.8.0.7\runtimes\win-$(NetHostPlatform)\native\</HostfxrPath>
     <ProjectAdditionalIncludeDirectories>$(NetHostPath)</ProjectAdditionalIncludeDirectories>
   </PropertyGroup>
 

--- a/src/ext/NetFx/netcoresearch/packages.config
+++ b/src/ext/NetFx/netcoresearch/packages.config
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="runtime.win-arm64.Microsoft.NETCore.DotNetAppHost" version="6.0.4" targetFramework="native" />
-  <package id="runtime.win-x64.Microsoft.NETCore.DotNetAppHost" version="6.0.4" targetFramework="native" />
-  <package id="runtime.win-x86.Microsoft.NETCore.DotNetAppHost" version="6.0.4" targetFramework="native" />
-  <package id="runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver" version="6.0.4" targetFramework="native" />
-  <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="6.0.4" targetFramework="native" />
-  <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="6.0.4" targetFramework="native" />
+  <package id="runtime.win-arm64.Microsoft.NETCore.DotNetAppHost" version="8.0.7" targetFramework="native" />
+  <package id="runtime.win-x64.Microsoft.NETCore.DotNetAppHost" version="8.0.7" targetFramework="native" />
+  <package id="runtime.win-x86.Microsoft.NETCore.DotNetAppHost" version="8.0.7" targetFramework="native" />
+  <package id="runtime.win-arm64.Microsoft.NETCore.DotNetHostResolver" version="8.0.7" targetFramework="native" />
+  <package id="runtime.win-x64.Microsoft.NETCore.DotNetHostResolver" version="8.0.7" targetFramework="native" />
+  <package id="runtime.win-x86.Microsoft.NETCore.DotNetHostResolver" version="8.0.7" targetFramework="native" />
 </packages>

--- a/src/ext/NetFx/netfx.cmd
+++ b/src/ext/NetFx/netfx.cmd
@@ -27,7 +27,7 @@ msbuild -Restore -p:Configuration=%_C% -tl -nologo -warnaserror -bl:%_L%\ext_net
 
 :: Test
 dotnet test ^
- %_B%\net6.0\WixToolsetTest.NetFx.dll ^
+ %_B%\net8.0\WixToolsetTest.NetFx.dll ^
  --nologo -l "trx;LogFileName=%_L%\TestResults\netfx.wixext.trx" || exit /b
 
 :: Pack

--- a/src/ext/NetFx/test/WixToolsetTest.Netfx/WixToolsetTest.Netfx.csproj
+++ b/src/ext/NetFx/test/WixToolsetTest.Netfx/WixToolsetTest.Netfx.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/PowerShell/test/WixToolsetTest.PowerShell/WixToolsetTest.Powershell.csproj
+++ b/src/ext/PowerShell/test/WixToolsetTest.PowerShell/WixToolsetTest.Powershell.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Sql/test/WixToolsetTest.Sql/WixToolsetTest.Sql.csproj
+++ b/src/ext/Sql/test/WixToolsetTest.Sql/WixToolsetTest.Sql.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
+++ b/src/ext/UI/test/WixToolsetTest.UI/UIExtensionFixture.cs
@@ -135,7 +135,7 @@ namespace WixToolsetTest.UI
             var results = build.BuildAndQuery(BuildX64, "Binary", "Dialog", "CustomAction", "ControlEvent", "InstallUISequence");
             Assert.Single(results, result => result.StartsWith("Dialog:WelcomeDlg\t"));
             Assert.Single(results, result => result.StartsWith("Dialog:CustomizeDlg\t"));
-            Assert.Empty(results.Where(result => result.StartsWith("Dialog:SetupTypeDlg\t")));
+            Assert.DoesNotContain(results, result => result.StartsWith("Dialog:SetupTypeDlg\t"));
             WixAssert.CompareLineByLine(new[]
             {
                 "Binary:WixUI_Bmp_Banner\t[Binary data]",
@@ -358,7 +358,7 @@ namespace WixToolsetTest.UI
                 "ControlEvent:InstallDirDlg\tNext\tDoAction\tWixUIValidatePath_X86\tNOT WIXUI_DONTVALIDATEPATH\t2",
             }, results.Where(result => result.StartsWith("ControlEvent:") && result.Contains("DoAction")).OrderBy(s => s).ToArray());
 
-            Assert.Empty(results.Where(result => result.Contains("LicenseAgreementDlg")).ToArray());
+            Assert.DoesNotContain(results, result => result.Contains("LicenseAgreementDlg"));
 
             WixAssert.CompareLineByLine(new[]
             {

--- a/src/ext/UI/test/WixToolsetTest.UI/WixToolsetTest.UI.csproj
+++ b/src/ext/UI/test/WixToolsetTest.UI/WixToolsetTest.UI.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Util/test/WixToolsetTest.Util/WixToolsetTest.Util.csproj
+++ b/src/ext/Util/test/WixToolsetTest.Util/WixToolsetTest.Util.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/ext/Util/util.cmd
+++ b/src/ext/Util/util.cmd
@@ -24,7 +24,7 @@ msbuild -Restore -p:Configuration=%_C% -tl -nologo -warnaserror -bl:%_L%\ext_uti
 
 :: Test
 dotnet test ^
- %_B%\net6.0\WixToolsetTest.Util.dll ^
+ %_B%\net8.0\WixToolsetTest.Util.dll ^
  --nologo -l "trx;LogFileName=%_L%\TestResults\util.wixext.trx" || exit /b
 
 :: Pack

--- a/src/ext/VisualStudio/test/WixToolsetTest.VisualStudio/WixToolsetTest.VisualStudio.csproj
+++ b/src/ext/VisualStudio/test/WixToolsetTest.VisualStudio/WixToolsetTest.VisualStudio.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -42,22 +42,22 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
-    <PackageVersion Include="System.DirectoryServices" Version="4.7.0" />
-    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="4.7.0" />
-    <PackageVersion Include="System.Management" Version="4.7.0" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="8.0.0" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="8.0.0" />
+    <PackageVersion Include="System.DirectoryServices" Version="8.0.0" />
+    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="8.0.0" />
+    <PackageVersion Include="System.Management" Version="8.0.0" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
+    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.Net.NetworkInformation" Version="4.3.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="1.8.1" />
-    <PackageVersion Include="System.Security.Principal.Windows" Version="4.7.0" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.7.1" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.9" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="8.0.0" />
+    <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
 
-    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="3.1.13" />
+    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="8.0.7" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Native" Version="3.10.2154" />
-    <PackageVersion Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
@@ -81,14 +81,14 @@
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
 
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="xunit" Version="2.8.1" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
-    <PackageVersion Include="xunit.assert" Version="2.8.1" />
+    <PackageVersion Include="xunit" Version="2.9.0" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
+    <PackageVersion Include="xunit.assert" Version="2.9.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Microsoft.NET.Tools.NETCoreCheck.x86" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Tools.NETCoreCheck.x64" Version="6.0.0" />
-    <PackageVersion Include="Microsoft.NET.Tools.NETCoreCheck.arm64" Version="6.0.0" />
+    <PackageVersion Include="Microsoft.NET.Tools.NETCoreCheck.x86" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.NET.Tools.NETCoreCheck.x64" Version="7.0.0" />
+    <PackageVersion Include="Microsoft.NET.Tools.NETCoreCheck.arm64" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -55,26 +55,26 @@
     <PackageVersion Include="System.Text.Encoding.CodePages" Version="8.0.0" />
     <PackageVersion Include="System.Text.Json" Version="8.0.4" />
 
-    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="8.0.7" />
-    <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Native" Version="3.10.2154" />
+    <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="8.0.8" />
+    <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Native" Version="3.11.2177" />
     <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="NuGet.Credentials" Version="6.10.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.10.1" />
-    <PackageVersion Include="NuGet.Versioning" Version="6.10.1" />
+    <PackageVersion Include="NuGet.Credentials" Version="6.11.0" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.11.0" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.11.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.4" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.11.4" />
   </ItemGroup>
 
   <!-- Keep the following versions in sync with internal\WixInternal.TestSupport.Native\packages.config -->
   <ItemGroup>
     <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
 
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.11.1" />
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
     <PackageVersion Include="xunit.assert" Version="2.9.0" />

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -66,14 +66,8 @@
     <PackageVersion Include="NuGet.Versioning" Version="6.10.1" />
   </ItemGroup>
 
-  <!--
-    These MSBuild versions are trapped in antiquity for heat.exe.
-  -->
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="14.3" />
-  </ItemGroup>
-  <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="15.7.179" />
+  <ItemGroup>
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="17.10.4" />
   </ItemGroup>
 
   <!-- Keep the following versions in sync with internal\WixInternal.TestSupport.Native\packages.config -->

--- a/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.props
+++ b/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.props
@@ -5,8 +5,8 @@
   <PropertyGroup>
     <RepoRootDir Condition=" '$(RepoRootDir)' == '' ">$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), .gitignore))</RepoRootDir>
   </PropertyGroup>
-  <Import Project="$(RepoRootDir)\packages\xunit.core.2.8.1\build\xunit.core.props" Condition="Exists('$(RepoRootDir)\packages\xunit.core.2.8.1\build\xunit.core.props')" />
-  <Import Project="$(RepoRootDir)\packages\xunit.runner.visualstudio.2.8.1\build\net462\xunit.runner.visualstudio.props" Condition="Exists('$(RepoRootDir)\packages\xunit.runner.visualstudio.2.8.1\build\net462\xunit.runner.visualstudio.props')" />
+  <Import Project="$(RepoRootDir)\packages\xunit.core.2.9.0\build\xunit.core.props" Condition="Exists('$(RepoRootDir)\packages\xunit.core.2.9.0\build\xunit.core.props')" />
+  <Import Project="$(RepoRootDir)\packages\xunit.runner.visualstudio.2.8.2\build\net462\xunit.runner.visualstudio.props" Condition="Exists('$(RepoRootDir)\packages\xunit.runner.visualstudio.2.8.2\build\net462\xunit.runner.visualstudio.props')" />
   <PropertyGroup>
     <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
   </PropertyGroup>

--- a/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.targets
+++ b/src/internal/WixInternal.TestSupport.Native/build/WixInternal.TestSupport.Native.targets
@@ -22,28 +22,28 @@
       <HintPath>$(RootPackagesFolder)xunit.abstractions.2.0.3\lib\netstandard2.0\xunit.abstractions.dll</HintPath>
     </Reference>
     <Reference Include="xunit.assert">
-      <HintPath>$(RootPackagesFolder)xunit.assert.2.8.1\lib\netstandard1.1\xunit.assert.dll</HintPath>
+      <HintPath>$(RootPackagesFolder)xunit.assert.2.9.0\lib\netstandard1.1\xunit.assert.dll</HintPath>
     </Reference>
     <Reference Include="xunit.core">
-      <HintPath>$(RootPackagesFolder)xunit.extensibility.core.2.8.1\lib\netstandard1.1\xunit.core.dll</HintPath>
+      <HintPath>$(RootPackagesFolder)xunit.extensibility.core.2.9.0\lib\netstandard1.1\xunit.core.dll</HintPath>
     </Reference>
     <Reference Include="xunit.execution.desktop">
-      <HintPath>$(RootPackagesFolder)xunit.extensibility.execution.2.8.1\lib\net452\xunit.execution.desktop.dll</HintPath>
+      <HintPath>$(RootPackagesFolder)xunit.extensibility.execution.2.9.0\lib\net452\xunit.execution.desktop.dll</HintPath>
     </Reference>
   </ItemGroup>
 
-  <Import Project="$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.targets" Condition="Exists('$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.targets')" />
+  <Import Project="$(RootPackagesFolder)xunit.core.2.9.0\build\xunit.core.targets" Condition="Exists('$(RootPackagesFolder)xunit.core.2.9.0\build\xunit.core.targets')" />
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.props'))" />
-    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.8.1\build\xunit.core.targets'))" />
-    <Error Condition="!Exists('$(RootPackagesFolder)xunit.runner.visualstudio.2.8.1\build\net462\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.runner.visualstudio.2.8.1\build\net462\xunit.runner.visualstudio.props'))" />
+    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.9.0\build\xunit.core.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.9.0\build\xunit.core.props'))" />
+    <Error Condition="!Exists('$(RootPackagesFolder)xunit.core.2.9.0\build\xunit.core.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.core.2.9.0\build\xunit.core.targets'))" />
+    <Error Condition="!Exists('$(RootPackagesFolder)xunit.runner.visualstudio.2.8.2\build\net462\xunit.runner.visualstudio.props')" Text="$([System.String]::Format('$(ErrorText)', '$(RootPackagesFolder)xunit.runner.visualstudio.2.8.2\build\net462\xunit.runner.visualstudio.props'))" />
   </Target>
 
-  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.8.1\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x86" Condition=" '$(Platform)'!='x64' " />
-  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.8.1\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x64" Condition=" '$(Platform)'=='x64' " />
+  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.9.0\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x86" Condition=" '$(Platform)'!='x64' " />
+  <UsingTask AssemblyFile="$(RootPackagesFolder)xunit.runner.msbuild.2.9.0\build\net452\xunit.runner.msbuild.net452.dll" TaskName="Xunit.Runner.MSBuild.xunit" Architecture="x64" Condition=" '$(Platform)'=='x64' " />
   <Target Name="Test">
     <!-- https://xunit.net/docs/running-tests-in-msbuild -->
     <!-- https://github.com/xunit/xunit/issues/2188 -->

--- a/src/internal/WixInternal.TestSupport.Native/packages.config
+++ b/src/internal/WixInternal.TestSupport.Native/packages.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 
 <packages>
@@ -7,10 +7,10 @@
     when any of these versions are updated.
   -->
   <package id="xunit.abstractions" version="2.0.3" />
-  <package id="xunit.assert" version="2.8.1" />
-  <package id="xunit.core" version="2.8.1" />
-  <package id="xunit.extensibility.core" version="2.8.1" />
-  <package id="xunit.extensibility.execution" version="2.8.1" />
-  <package id="xunit.runner.msbuild" version="2.8.1" />
-  <package id="xunit.runner.visualstudio" version="2.8.1" />
+  <package id="xunit.assert" version="2.9.0" />
+  <package id="xunit.core" version="2.9.0" />
+  <package id="xunit.extensibility.core" version="2.9.0" />
+  <package id="xunit.extensibility.execution" version="2.9.0" />
+  <package id="xunit.runner.msbuild" version="2.9.0" />
+  <package id="xunit.runner.visualstudio" version="2.8.2" />
 </packages>

--- a/src/libs/libs.cmd
+++ b/src/libs/libs.cmd
@@ -22,7 +22,7 @@
 msbuild -Restore libs_t.proj -p:Configuration=%_C% -tl -nologo -m -warnaserror -bl:%_L%\libs_build.binlog || exit /b
 
 dotnet test ^
- %_B%\net6.0\WixToolsetTest.Versioning.dll ^
+ %_B%\net8.0\WixToolsetTest.Versioning.dll ^
  %_B%\x86\DUtilUnitTest.dll ^
  %_B%\x64\DUtilUnitTest.dll ^
  --nologo -l "trx;LogFileName=%_L%\TestResults\libs.trx" || exit /b

--- a/src/libs/test/WixToolsetTest.Versioning/WixToolsetTest.Versioning.csproj
+++ b/src/libs/test/WixToolsetTest.Versioning/WixToolsetTest.Versioning.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/test/burn/Directory.wixproj.props
+++ b/src/test/burn/Directory.wixproj.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TestGroupName Condition=" '$(TestGroupName)'=='' ">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))))</TestGroupName>
     <BaseIntermediateOutputPath>$(BaseOutputPath)obj\$(TestGroupName)\$(ProjectName)\</BaseIntermediateOutputPath>
-    <OutputPath>$(OutputPath)net6.0-windows\TestData\$(TestGroupName)\</OutputPath>
+    <OutputPath>$(OutputPath)net8.0-windows\TestData\$(TestGroupName)\</OutputPath>
     <DefaultCompressionLevel>None</DefaultCompressionLevel>
     <CompilerAdditionalOptions>-wx</CompilerAdditionalOptions>
     <SuppressSpecificWarnings>1154;$(SuppressSpecificWarnings)</SuppressSpecificWarnings>

--- a/src/test/burn/README.md
+++ b/src/test/burn/README.md
@@ -10,8 +10,8 @@ They modify machine state so it's strongly recommended *not* to run these tests 
 They should be run on a VM instead, where you can easily roll back.
 
 1. Run build.cmd to build everything (the tests will not automatically run).
-1. Copy the build\IntegrationBurn\Debug\net6.0-windows folder to your VM.
-1. Open an elevated command prompt and navigate to the net6.0-windows folder.
+1. Copy the build\IntegrationBurn\Debug\net8.0-windows folder to your VM.
+1. Open an elevated command prompt and navigate to the net8.0-windows folder.
 1. Run the runtests.cmd file to run the tests.
 
 You can modify the runtests.cmd to run specific tests.

--- a/src/test/burn/README.md
+++ b/src/test/burn/README.md
@@ -20,9 +20,9 @@ For example, the following line runs only the specified test:
 > dotnet test --filter WixToolsetTest.BurnE2E.BasicFunctionalityTests.CanInstallAndUninstallSimpleBundle_x86_wixstdba WixToolsetTest.BurnE2E.dll
 
 The VM must have:
-1. x64 .NET Core SDK of 6.0 or later (for the test runner and .NET Core TestBA)
+1. x64 .NET Core SDK of 8.0 or later (for the test runner and .NET Core TestBA)
 1. Any version of .NET Framework (for the .NET Framework TestBA)
-1. x86 .NET Core Desktop Runtime of 6.0 or later (for the .NET Core TestBA)
+1. x86 .NET Core Desktop Runtime of 8.0 or later (for the .NET Core TestBA)
 
 ## Building with local changes
 

--- a/src/test/burn/TestBA/TestBA.csproj
+++ b/src/test/burn/TestBA/TestBA.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>TestBA</AssemblyName>
     <RootNamespace>WixToolset.Test.BA</RootNamespace>

--- a/src/test/burn/TestBA/TestBA_x64.csproj
+++ b/src/test/burn/TestBA/TestBA_x64.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>TestBA</AssemblyName>
     <RootNamespace>WixToolset.Test.BA</RootNamespace>

--- a/src/test/burn/TestData/CacheTests/BundleC/BundleC.wixproj
+++ b/src/test/burn/TestData/CacheTests/BundleC/BundleC.wixproj
@@ -17,7 +17,7 @@
   </ItemGroup>
   <!-- We do this dynamically to avoid committing such a large file to source control. -->
   <Target Name="CreateLargeFile" AfterTargets="BeforeBuild" Inputs="$(MSBuildProjectFullPath)" Outputs="$(MSBuildProjectDirectory)\fivegb.file">
-    <Exec Command='"$(BaseOutputPath)$(Configuration)\net6.0\win-x86\testexe.exe" /lf "fivegb.file|5368709120' WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command='"$(BaseOutputPath)$(Configuration)\net8.0\win-x86\testexe.exe" /lf "fivegb.file|5368709120' WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
   <!-- We do this to avoid copying such a large file to the VM to run the tests. -->
   <Target Name="DeleteLargeFile" AfterTargets="AfterBuild">

--- a/src/test/burn/TestData/Manual/BundleB/BundleB.wixproj
+++ b/src/test/burn/TestData/Manual/BundleB/BundleB.wixproj
@@ -31,8 +31,8 @@
 
   <!-- We do this dynamically to avoid committing so many files to source control. -->
   <Target Name="CreateThousandsOfFiles" AfterTargets="BeforeBuild">
-    <Exec Command='"$(BaseOutputPath)$(Configuration)\net6.0\win-x86\testexe.exe" /gf "BAPayloads|10000' WorkingDirectory="$(MSBuildProjectDirectory)" />
-    <Exec Command='"$(BaseOutputPath)$(Configuration)\net6.0\win-x86\testexe.exe" /gf "PackagePayloads|10000' WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command='"$(BaseOutputPath)$(Configuration)\net8.0\win-x86\testexe.exe" /gf "BAPayloads|10000' WorkingDirectory="$(MSBuildProjectDirectory)" />
+    <Exec Command='"$(BaseOutputPath)$(Configuration)\net8.0\win-x86\testexe.exe" /gf "PackagePayloads|10000' WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
   <Target Name="DeleteThousandsOfFiles" AfterTargets="AfterBuild">

--- a/src/test/burn/TestData/PrereqBaTests/BundleA/BundleA.wixproj
+++ b/src/test/burn/TestData/PrereqBaTests/BundleA/BundleA.wixproj
@@ -9,7 +9,7 @@
     <Compile Include="..\..\Templates\Bundle.wxs" Link="Bundle.wxs" />
   </ItemGroup>
   <ItemGroup>
-    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net6.0-windows\win-x86" BindName="dncx86" />
+    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net8.0-windows\win-x86" BindName="dncx86" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PackageA\PackageA.wixproj" />

--- a/src/test/burn/TestData/PrereqBaTests/BundleC/BundleC.wixproj
+++ b/src/test/burn/TestData/PrereqBaTests/BundleC/BundleC.wixproj
@@ -9,7 +9,7 @@
     <Compile Include="..\..\Templates\Bundle.wxs" Link="Bundle.wxs" />
   </ItemGroup>
   <ItemGroup>
-    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net6.0-windows\win-x86" BindName="dncx86" />
+    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net8.0-windows\win-x86" BindName="dncx86" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PackageA\PackageA.wixproj" />

--- a/src/test/burn/TestData/PrereqBaTests/BundleE/BundleE.wixproj
+++ b/src/test/burn/TestData/PrereqBaTests/BundleE/BundleE.wixproj
@@ -9,7 +9,7 @@
     <Compile Include="..\..\Templates\Bundle.wxs" Link="Bundle.wxs" />
   </ItemGroup>
   <ItemGroup>
-    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net6.0-windows\win-x86" BindName="dncx86" />
+    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net8.0-windows\win-x86" BindName="dncx86" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\PrereqBaf\PrereqBaf.vcxproj" />

--- a/src/test/burn/TestData/TestBA/TestBAWixlib/testbawixlib.wixproj
+++ b/src/test/burn/TestData/TestBA/TestBAWixlib/testbawixlib.wixproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net462\win-x86" BindName="net2x86" />
     <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net472\win-x86" BindName="net4x86" />
-    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net6.0-windows\win-x86" BindName="dncx86" />
+    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net8.0-windows\win-x86" BindName="dncx86" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TestBA\TestBA.csproj" />

--- a/src/test/burn/TestData/TestBA/TestBAWixlib_x64/testbawixlib_x64.wixproj
+++ b/src/test/burn/TestData/TestBA/TestBAWixlib_x64/testbawixlib_x64.wixproj
@@ -9,7 +9,7 @@
   <ItemGroup>
     <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net462\win-x64" BindName="net2x64" />
     <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net472\win-x64" BindName="net4x64" />
-    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net6.0-windows\win-x64" BindName="dncx64" />
+    <BindInputPaths Include="$(BaseOutputPath)$(Configuration)\net8.0-windows\win-x64" BindName="dncx64" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\..\TestBA\TestBA_x64.csproj" />

--- a/src/test/burn/TestExe/TestExe.csproj
+++ b/src/test/burn/TestExe/TestExe.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net462;net8.0</TargetFrameworks>
     <AssemblyName>TestExe</AssemblyName>
     <RootNamespace>TestExe</RootNamespace>
     <OutputType>Exe</OutputType>

--- a/src/test/burn/WixTestTools/WixTestTools.csproj
+++ b/src/test/burn/WixTestTools/WixTestTools.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsWixTestSupportProject>true</IsWixTestSupportProject>
   </PropertyGroup>

--- a/src/test/burn/WixToolset.WixBA/WixToolset.WixBA.csproj
+++ b/src/test/burn/WixToolset.WixBA/WixToolset.WixBA.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>WixToolset.WixBA</AssemblyName>
     <RootNamespace>WixToolset.WixBA</RootNamespace>

--- a/src/test/burn/WixToolset.WixBA/WixToolset.WixBA_x64.csproj
+++ b/src/test/burn/WixToolset.WixBA/WixToolset.WixBA_x64.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0-windows</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>WixToolset.WixBA</AssemblyName>
     <RootNamespace>WixToolset.WixBA</RootNamespace>

--- a/src/test/burn/WixToolsetTest.BurnE2E/WixToolsetTest.BurnE2E.csproj
+++ b/src/test/burn/WixToolsetTest.BurnE2E/WixToolsetTest.BurnE2E.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>

--- a/src/test/burn/test_burn.cmd
+++ b/src/test/burn/test_burn.cmd
@@ -16,8 +16,8 @@
 msbuild -Restore -p:Configuration=%_C% -tl -nologo -m -warnaserror -bl:%_L%\test_burn_build.binlog || exit /b
 msbuild -Restore TestData\TestData.proj -p:Configuration=%_C% -tl -nologo -m -warnaserror -bl:%_L%\test_burn_data_build.binlog || exit /b
 
-"%_B%\net462\win-x86\testexe.exe" /dm "%_B%\net6.0-windows\testhost.exe"
-mt.exe -manifest "WixToolsetTest.BurnE2E\testhost.longpathaware.manifest" -updateresource:"%_B%\net6.0-windows\testhost.exe"
+"%_B%\net462\win-x86\testexe.exe" /dm "%_B%\net8.0-windows\testhost.exe"
+mt.exe -manifest "WixToolsetTest.BurnE2E\testhost.longpathaware.manifest" -updateresource:"%_B%\net8.0-windows\testhost.exe"
 
 @if not "%RuntimeTestsEnabled%"=="true" goto :LExit
 

--- a/src/test/msi/Directory.wixproj.props
+++ b/src/test/msi/Directory.wixproj.props
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TestGroupName Condition=" '$(TestGroupName)'=='' ">$([System.IO.Path]::GetFileName($([System.IO.Path]::GetDirectoryName($(MSBuildProjectDirectory)))))</TestGroupName>
     <BaseIntermediateOutputPath>$(BaseOutputPath)obj\$(TestGroupName)\$(ProjectName)\</BaseIntermediateOutputPath>
-    <OutputPath>$(OutputPath)net6.0-windows\TestData\$(TestGroupName)\</OutputPath>
+    <OutputPath>$(OutputPath)net8.0-windows\TestData\$(TestGroupName)\</OutputPath>
     <DefaultCompressionLevel>None</DefaultCompressionLevel>
     <CompilerAdditionalOptions>-wx</CompilerAdditionalOptions>
     <SuppressValidation>true</SuppressValidation>

--- a/src/test/msi/README.md
+++ b/src/test/msi/README.md
@@ -10,8 +10,8 @@ They modify machine state so it's strongly recommended *not* to run these tests 
 They should be run on a VM instead, where you can easily roll back.
 
 1. Run build.cmd to build everything (the tests will not automatically run).
-1. Copy the build\IntegrationMsi\Debug\net6.0-windows folder to your VM.
-1. Open an elevated command prompt and navigate to the net6.0-windows folder.
+1. Copy the build\IntegrationMsi\Debug\net8.0-windows folder to your VM.
+1. Open an elevated command prompt and navigate to the net8.0-windows folder.
 1. Run the runtests.cmd file to run the tests.
 
 You can modify the runtests.cmd to run specific tests.

--- a/src/test/msi/WixToolsetTest.MsiE2E/WixToolsetTest.MsiE2E.csproj
+++ b/src/test/msi/WixToolsetTest.MsiE2E/WixToolsetTest.MsiE2E.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net8.0-windows</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>

--- a/src/test/wix/TestData/CsprojClassLibraryMultiFramework/CsprojClassLibraryMultiFramework.csproj
+++ b/src/test/wix/TestData/CsprojClassLibraryMultiFramework/CsprojClassLibraryMultiFramework.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <DebugType>embedded</DebugType>
   </PropertyGroup>
 

--- a/src/test/wix/TestData/CsprojClassLibraryMultiTarget/CsprojClassLibraryMultiTarget.csproj
+++ b/src/test/wix/TestData/CsprojClassLibraryMultiTarget/CsprojClassLibraryMultiTarget.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net472;net8.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/wix/TestData/CsprojConsoleMultiFramework/CsprojConsoleMultiFramework.csproj
+++ b/src/test/wix/TestData/CsprojConsoleMultiFramework/CsprojConsoleMultiFramework.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <RuntimeIdentifiers>win-x86</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/src/test/wix/TestData/CsprojConsoleNetCore/CsprojConsoleNetCore.csproj
+++ b/src/test/wix/TestData/CsprojConsoleNetCore/CsprojConsoleNetCore.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x86</RuntimeIdentifiers>
   </PropertyGroup>
 

--- a/src/test/wix/TestData/CsprojWebApplicationNetCore/CsprojWebApplicationNetCore.csproj
+++ b/src/test/wix/TestData/CsprojWebApplicationNetCore/CsprojWebApplicationNetCore.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/test/wix/TestData/WixprojLibraryMultiFramework/Library.wxs
+++ b/src/test/wix/TestData/WixprojLibraryMultiFramework/Library.wxs
@@ -1,13 +1,13 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs" xmlns:ui="http://wixtoolset.org/schemas/v4/wxs/ui">
   <Fragment>
-    <ComponentGroup Id='CsprojClassLibraryMultiFrameworkNet60' Directory='ApplicationFolder' Subdirectory="net6.0">
+    <ComponentGroup Id='CsprojClassLibraryMultiFrameworkNet60' Directory='ApplicationFolder' Subdirectory="net8.0">
       <Component>
-        <File Id="Net60" Source='!(bindpath.CsprojConsoleMultiFramework.net6.0)CsprojConsoleMultiFramework.exe' />
-        <File Source='!(bindpath.CsprojConsoleMultiFramework.net6.0)CsprojConsoleMultiFramework.deps.json' />
-        <File Source='!(bindpath.CsprojConsoleMultiFramework.net6.0)CsprojConsoleMultiFramework.runtimeconfig.json' />
+        <File Id="Net60" Source='!(bindpath.CsprojConsoleMultiFramework.net8.0)CsprojConsoleMultiFramework.exe' />
+        <File Source='!(bindpath.CsprojConsoleMultiFramework.net8.0)CsprojConsoleMultiFramework.deps.json' />
+        <File Source='!(bindpath.CsprojConsoleMultiFramework.net8.0)CsprojConsoleMultiFramework.runtimeconfig.json' />
       </Component>
       <Component>
-        <File Source='!(bindpath.CsprojConsoleMultiFramework.net6.0)CsprojClassLibraryMultiFramework.dll' />
+        <File Source='!(bindpath.CsprojConsoleMultiFramework.net8.0)CsprojClassLibraryMultiFramework.dll' />
       </Component>
     </ComponentGroup>
   </Fragment>

--- a/src/test/wix/TestData/WixprojLibraryMultiFramework/WixprojLibraryMultiFramework.wixproj
+++ b/src/test/wix/TestData/WixprojLibraryMultiFramework/WixprojLibraryMultiFramework.wixproj
@@ -7,6 +7,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\CsprojConsoleMultiFramework\CsprojConsoleMultiFramework.csproj"
-                      TargetFrameworks="net472;net6.0" Publish="true" />
+                      TargetFrameworks="net472;net8.0" Publish="true" />
   </ItemGroup>
 </Project>

--- a/src/test/wix/TestData/WixprojPackageCsprojWebApplicationNetCore/WixprojPackageCsprojWebApplicationNetCore.wixproj
+++ b/src/test/wix/TestData/WixprojPackageCsprojWebApplicationNetCore/WixprojPackageCsprojWebApplicationNetCore.wixproj
@@ -1,7 +1,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project Sdk='WixToolset.Sdk'>
 <!-- <Project> -->
-  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net6.0\Sdk\Sdk.props' /> -->
+  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net8.0\Sdk\Sdk.props' /> -->
 
   <PropertyGroup>
     <!-- <WixBinDir>D:\src\wix4\build\wix\Debug\net472\</WixBinDir> -->
@@ -13,5 +13,5 @@
     <ProjectReference Include="..\CsprojWebApplicationNetCore\CsprojWebApplicationNetCore.csproj" Publish="true" />
   </ItemGroup>
 
-  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net6.0\Sdk\Sdk.targets' /> -->
+  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net8.0\Sdk\Sdk.targets' /> -->
 </Project>

--- a/src/test/wix/TestData/WixprojPackageCsprojWpfNetCore/WixprojPackageCsprojWebApplicationNetCore.wixproj
+++ b/src/test/wix/TestData/WixprojPackageCsprojWpfNetCore/WixprojPackageCsprojWebApplicationNetCore.wixproj
@@ -1,7 +1,7 @@
 <!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
 <Project Sdk='WixToolset.Sdk'>
 <!-- <Project> -->
-  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net6.0\Sdk\Sdk.props' /> -->
+  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net8.0\Sdk\Sdk.props' /> -->
 
   <PropertyGroup>
     <!-- <WixBinDir>D:\src\wix4\build\wix\Debug\net472\</WixBinDir> -->
@@ -13,5 +13,5 @@
     <ProjectReference Include="..\CsprojWpfNetCore\CsprojWpfNetCore.csproj" Publish="true" />
   </ItemGroup>
 
-  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net6.0\Sdk\Sdk.targets' /> -->
+  <!-- <Import Sdk="WixToolset.Sdk" Project='D:\src\wix4\build\wix\Debug\net8.0\Sdk\Sdk.targets' /> -->
 </Project>

--- a/src/tools/WixToolset.Heat/WixToolset.Heat.csproj
+++ b/src/tools/WixToolset.Heat/WixToolset.Heat.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <Description>WiX Toolset Heat MSBuild integration</Description>
     <PublishDir>$(PublishRoot)WixToolset.Heat\</PublishDir>
     <NuspecFile>$(MSBuildThisFileName).nuspec</NuspecFile>

--- a/src/tools/WixToolset.Heat/WixToolset.Heat.targets
+++ b/src/tools/WixToolset.Heat/WixToolset.Heat.targets
@@ -5,7 +5,7 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- These properties can be overridden to support non-default installations. -->
   <PropertyGroup>
-    <WixHeatBinDir Condition=" '$(WixHeatBinDir)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">$(MSBuildThisFileDirectory)..\tools\net6.0\</WixHeatBinDir>
+    <WixHeatBinDir Condition=" '$(WixHeatBinDir)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">$(MSBuildThisFileDirectory)..\tools\net8.0\</WixHeatBinDir>
     <WixHeatBinDir Condition=" '$(WixHeatBinDir)' == '' ">$(MSBuildThisFileDirectory)..\tools\net472\</WixHeatBinDir>
     <WixHeatTasksPath Condition=" '$(WixHeatTasksPath)' == '' ">$(WixHeatBinDir)WixToolset.HeatTasks.dll</WixHeatTasksPath>
 

--- a/src/tools/WixToolset.HeatTasks/WixToolset.HeatTasks.csproj
+++ b/src/tools/WixToolset.HeatTasks/WixToolset.HeatTasks.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <Title>WiX Toolset Heat MSBuild Tasks</Title>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/tools/heat/app.config
+++ b/src/tools/heat/app.config
@@ -6,5 +6,11 @@
     <runtime>
         <loadFromRemoteSources enabled="true"/>
         <AppContextSwitchOverrides value="Switch.System.IO.UseLegacyPathHandling=false;Switch.System.IO.BlockLongPaths=false" />
+        <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+            <dependentAssembly>
+                <assemblyIdentity name="System.Memory" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
+                <bindingRedirect oldVersion="0.0.0.0-4.0.1.2" newVersion="4.0.1.2" />
+            </dependentAssembly>
+        </assemblyBinding>
     </runtime>
 </configuration>

--- a/src/tools/heat/heat.csproj
+++ b/src/tools/heat/heat.csproj
@@ -3,13 +3,13 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Description>Harvester</Description>
     <Title>WiX Toolset Harvester</Title>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
-    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)'=='' and '$(TargetFramework)'!='net6.0' ">win-x86;win-x64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)'=='' and '$(TargetFramework)'!='net8.0' ">win-x86;win-x64</RuntimeIdentifiers>
     <AppConfig>app.config</AppConfig>
     <ApplicationManifest>heat.exe.manifest</ApplicationManifest>
     <RollForward>LatestMajor</RollForward>

--- a/src/tools/publish_t.proj
+++ b/src/tools/publish_t.proj
@@ -2,23 +2,23 @@
   <PropertyGroup>
     <StagePublishX86>$(BaseIntermediateOutputPath)$(Configuration)\net472\x86\</StagePublishX86>
     <StagePublishX64>$(BaseIntermediateOutputPath)$(Configuration)\net472\x64\</StagePublishX64>
-    <StagePublishDnc>$(BaseIntermediateOutputPath)$(Configuration)\net6.0\</StagePublishDnc>
+    <StagePublishDnc>$(BaseIntermediateOutputPath)$(Configuration)\net8.0\</StagePublishDnc>
 
     <PublishBuildFolder>$(PublishRoot)WixToolset.Heat\build\</PublishBuildFolder>
     <PublishHere>$(PublishRoot)WixToolset.Heat\tools\net472\</PublishHere>
     <PublishX86>$(PublishRoot)WixToolset.Heat\tools\net472\x86\</PublishX86>
     <PublishX64>$(PublishRoot)WixToolset.Heat\tools\net472\x64\</PublishX64>
-    <PublishDnc>$(PublishRoot)WixToolset.Heat\tools\net6.0\</PublishDnc>
+    <PublishDnc>$(PublishRoot)WixToolset.Heat\tools\net8.0\</PublishDnc>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="WixToolset.HeatTasks\WixToolset.HeatTasks.csproj" Properties="TargetFramework=net472;PublishDir=$(StagePublishX86)WixToolset.HeatTasks" Targets="Publish" />
-    <ProjectReference Include="WixToolset.HeatTasks\WixToolset.HeatTasks.csproj" Properties="TargetFramework=net6.0;UseAppHost=false;PublishDir=$(StagePublishDnc)WixToolset.HeatTasks" Targets="Publish" />
+    <ProjectReference Include="WixToolset.HeatTasks\WixToolset.HeatTasks.csproj" Properties="TargetFramework=net8.0;UseAppHost=false;PublishDir=$(StagePublishDnc)WixToolset.HeatTasks" Targets="Publish" />
 
     <!-- heat.exe doesn't need to filter any files so publish it straight into its final location -->
     <ProjectReference Include="heat\heat.csproj" Properties="TargetFramework=net472;RuntimeIdentifier=win-x86;PublishDir=$(PublishX86)" Targets="Publish" />
     <ProjectReference Include="heat\heat.csproj" Properties="TargetFramework=net472;RuntimeIdentifier=win-x64;PublishDir=$(PublishX64)" Targets="Publish" />
-    <ProjectReference Include="heat\heat.csproj" Properties="TargetFramework=net6.0-windows;UseAppHost=false;PublishDir=$(PublishDnc)" Targets="Publish" />
+    <ProjectReference Include="heat\heat.csproj" Properties="TargetFramework=net8.0-windows;UseAppHost=false;PublishDir=$(PublishDnc)" Targets="Publish" />
   </ItemGroup>
 
   <Target Name="CopyToFinalPublishFolder" AfterTargets="Build">

--- a/src/wix/WixToolset.BuildTasks/WixToolset.BuildTasks.csproj
+++ b/src/wix/WixToolset.BuildTasks/WixToolset.BuildTasks.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <Description></Description>
     <Title>WiX Toolset MSBuild Tasks</Title>
     <DebugType>embedded</DebugType>

--- a/src/wix/WixToolset.Sdk/WixToolset.Sdk.csproj
+++ b/src/wix/WixToolset.Sdk/WixToolset.Sdk.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Description>WiX Toolset MSBuild integration</Description>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PublishDir>$(PublishRoot)WixToolset.Sdk\</PublishDir>

--- a/src/wix/WixToolset.Sdk/tools/wix.targets
+++ b/src/wix/WixToolset.Sdk/tools/wix.targets
@@ -26,7 +26,7 @@
 
   <!-- These properties can be overridden to support non-default installations. -->
   <PropertyGroup>
-    <WixBinDir Condition=" '$(WixBinDir)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">$(MSBuildThisFileDirectory)net6.0\</WixBinDir>
+    <WixBinDir Condition=" '$(WixBinDir)' == '' and '$(MSBuildRuntimeType)' == 'Core' ">$(MSBuildThisFileDirectory)net8.0\</WixBinDir>
     <WixBinDir Condition=" '$(WixBinDir)' == '' ">$(MSBuildThisFileDirectory)net472\</WixBinDir>
     <WixTasksPath Condition=" '$(WixTasksPath)' == '' ">$(WixBinDir)WixToolset.BuildTasks.dll</WixTasksPath>
   </PropertyGroup>

--- a/src/wix/pack-wix/pack-wix.csproj
+++ b/src/wix/pack-wix/pack-wix.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IncludeBuildOutput>false</IncludeBuildOutput>
     <Title>The WiX Toolset command-line interface.</Title>
     <Description>The WiX Toolset lets developers create installers for Windows. This package contains the WiX Toolset command-line interface.</Description>

--- a/src/wix/pack-wix/pack-wix.nuspec
+++ b/src/wix/pack-wix/pack-wix.nuspec
@@ -18,8 +18,8 @@
   </metadata>
 
   <files>
-    <file src="$projectFolder$\DotnetToolSettings.xml" target="tools\net6.0\any" />
+    <file src="$projectFolder$\DotnetToolSettings.xml" target="tools\net8.0\any" />
     <file src="$projectFolder$\..\..\internal\images\wix.png" />
-    <file src="**" target="tools\net6.0\any" exclude="**\*.xml;**\WixToolset.Core.Native.targets" />
+    <file src="**" target="tools\net8.0\any" exclude="**\*.xml;**\WixToolset.Core.Native.targets" />
   </files>
 </package>

--- a/src/wix/publish_t.proj
+++ b/src/wix/publish_t.proj
@@ -2,27 +2,27 @@
   <PropertyGroup>
     <StagePublishX86>$(BaseIntermediateOutputPath)$(Configuration)\net472\x86\</StagePublishX86>
     <StagePublishX64>$(BaseIntermediateOutputPath)$(Configuration)\net472\x64\</StagePublishX64>
-    <StagePublishDnc>$(BaseIntermediateOutputPath)$(Configuration)\net6.0\</StagePublishDnc>
+    <StagePublishDnc>$(BaseIntermediateOutputPath)$(Configuration)\net8.0\</StagePublishDnc>
 
     <PublishBuildFolder>$(PublishRoot)WixToolset.Sdk\build\</PublishBuildFolder>
     <PublishHere>$(PublishRoot)WixToolset.Sdk\tools\net472\</PublishHere>
     <PublishX86>$(PublishRoot)WixToolset.Sdk\tools\net472\x86\</PublishX86>
     <PublishX64>$(PublishRoot)WixToolset.Sdk\tools\net472\x64\</PublishX64>
     <PublishARM64>$(PublishRoot)WixToolset.Sdk\tools\net472\arm64\</PublishARM64>
-    <PublishDnc>$(PublishRoot)WixToolset.Sdk\tools\net6.0\</PublishDnc>
+    <PublishDnc>$(PublishRoot)WixToolset.Sdk\tools\net8.0\</PublishDnc>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="WixToolset.BuildTasks\WixToolset.BuildTasks.csproj" Properties="TargetFramework=net472;PublishDir=$(StagePublishX86)WixToolset.BuildTasks" Targets="Publish" />
-    <ProjectReference Include="WixToolset.BuildTasks\WixToolset.BuildTasks.csproj" Properties="TargetFramework=net6.0;UseAppHost=false;PublishDir=$(StagePublishDnc)WixToolset.BuildTasks" Targets="Publish" />
+    <ProjectReference Include="WixToolset.BuildTasks\WixToolset.BuildTasks.csproj" Properties="TargetFramework=net8.0;UseAppHost=false;PublishDir=$(StagePublishDnc)WixToolset.BuildTasks" Targets="Publish" />
 
-    <ProjectReference Include="wix\wix.csproj" Properties="TargetFramework=net6.0;PublishDir=$(BaseOutputPath)$(Configuration)\publish\wix\" Targets="Publish" />
+    <ProjectReference Include="wix\wix.csproj" Properties="TargetFramework=net8.0;PublishDir=$(BaseOutputPath)$(Configuration)\publish\wix\" Targets="Publish" />
 
     <!-- wix.exe doesn't need to filter any files so publish it straight into its final location -->
     <ProjectReference Include="wix\wix.csproj" Properties="TargetFramework=net472;RuntimeIdentifier=win-x86;PublishDir=$(PublishX86)" Targets="Publish" />
     <ProjectReference Include="wix\wix.csproj" Properties="TargetFramework=net472;RuntimeIdentifier=win-x64;PublishDir=$(PublishX64)" Targets="Publish" />
     <ProjectReference Include="wix\wix.csproj" Properties="TargetFramework=net472;RuntimeIdentifier=win-arm64;PublishDir=$(PublishARM64)" Targets="Publish" />
-    <ProjectReference Include="wix\wix.csproj" Properties="TargetFramework=net6.0;UseAppHost=false;PublishDir=$(PublishDnc)" Targets="Publish" />
+    <ProjectReference Include="wix\wix.csproj" Properties="TargetFramework=net8.0;UseAppHost=false;PublishDir=$(PublishDnc)" Targets="Publish" />
   </ItemGroup>
 
   <Target Name="CopyToFinalPublishFolder" AfterTargets="Build">

--- a/src/wix/test/CompileCoreTestExtensionWixlib/CompileCoreTestExtensionWixlib.csproj
+++ b/src/wix/test/CompileCoreTestExtensionWixlib/CompileCoreTestExtensionWixlib.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <OutputType>Exe</OutputType>
     <SignOutput>false</SignOutput>

--- a/src/wix/test/Example.Extension/Example.Extension.csproj
+++ b/src/wix/test/Example.Extension/Example.Extension.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <DebugType>embedded</DebugType>
     <SignOutput>false</SignOutput>

--- a/src/wix/test/WixToolsetTest.Converters/WixToolsetTest.Converters.csproj
+++ b/src/wix/test/WixToolsetTest.Converters/WixToolsetTest.Converters.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/wix/test/WixToolsetTest.Core.Native/WixToolsetTest.Core.Native.csproj
+++ b/src/wix/test/WixToolsetTest.Core.Native/WixToolsetTest.Core.Native.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifier>win-x64</RuntimeIdentifier>
     <SelfContained>false</SelfContained>
     <RequiresNativeWixAssets>true</RequiresNativeWixAssets>

--- a/src/wix/test/WixToolsetTest.Core/WixToolsetTest.Core.csproj
+++ b/src/wix/test/WixToolsetTest.Core/WixToolsetTest.Core.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/BundleExtractionFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/BundleExtractionFixture.cs
@@ -38,7 +38,7 @@ namespace WixToolsetTest.CoreIntegration
                 });
 
                 result.AssertSuccess();
-                Assert.Empty(result.Messages.Where(m => m.Level == MessageLevel.Warning));
+                Assert.DoesNotContain(result.Messages, m => m.Level == MessageLevel.Warning);
 
                 Assert.True(File.Exists(exePath));
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/BundleFixture.cs
@@ -100,7 +100,7 @@ namespace WixToolsetTest.CoreIntegration
                 });
 
                 result.AssertSuccess();
-                Assert.Empty(result.Messages.Where(m => m.Level == MessageLevel.Warning));
+                Assert.DoesNotContain(result.Messages, m => m.Level == MessageLevel.Warning);
 
                 Assert.True(File.Exists(exePath));
                 Assert.True(File.Exists(pdbPath));

--- a/src/wix/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/WixToolsetTest.CoreIntegration.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RequiresNativeWixAssets>true</RequiresNativeWixAssets>
     <IsWixTestProject>true</IsWixTestProject>
   </PropertyGroup>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageReleaseAndDebug/Package.wxs
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageReleaseAndDebug/Package.wxs
@@ -14,10 +14,10 @@
                 <File Id="debug_net472_x64" Source="!(bindpath.TestExe.Debug.net472.win_x64)\e_sqlite3.dll" />
             </Component>
             <Component Subdirectory="debug_net6_x86">
-                <File Id="debug_net6_x86" Source="!(bindpath.TestExe.Debug.net6.0.win_x86)\e_sqlite3.dll" />
+                <File Id="debug_net6_x86" Source="!(bindpath.TestExe.Debug.net8.0.win_x86)\e_sqlite3.dll" />
             </Component>
             <Component Subdirectory="debug_net6_x64">
-                <File Id="debug_net6_x64" Source="!(bindpath.TestExe.Debug.net6.0.win_x64)\e_sqlite3.dll" />
+                <File Id="debug_net6_x64" Source="!(bindpath.TestExe.Debug.net8.0.win_x64)\e_sqlite3.dll" />
             </Component>
             <Component Subdirectory="release_net472_x86">
                 <File Id="release_net472_x86" Source="!(bindpath.TestExe.Release.net472.win_x86)\e_sqlite3.dll" />
@@ -26,10 +26,10 @@
                 <File Id="release_net472_x64" Source="!(bindpath.TestExe.Release.net472.win_x64)\e_sqlite3.dll" />
             </Component>
             <Component Subdirectory="release_net6_x86">
-                <File Id="release_net6_x86" Source="!(bindpath.TestExe.Release.net6.0.win_x86)\e_sqlite3.dll" />
+                <File Id="release_net6_x86" Source="!(bindpath.TestExe.Release.net8.0.win_x86)\e_sqlite3.dll" />
             </Component>
             <Component Subdirectory="release_net6_x64">
-                <File Id="release_net6_x64" Source="!(bindpath.TestExe.Release.net6.0.win_x64)\e_sqlite3.dll" />
+                <File Id="release_net6_x64" Source="!(bindpath.TestExe.Release.net8.0.win_x64)\e_sqlite3.dll" />
             </Component>
         </ComponentGroup>
     </Fragment>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageReleaseAndDebug/PackageReleaseAndDebug.wixproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageReleaseAndDebug/PackageReleaseAndDebug.wixproj
@@ -3,7 +3,7 @@
   <Import Project="$(WixMSBuildProps)" />
 
   <ItemGroup>
-    <ProjectReference Include="..\TestExe\TestExe.csproj" Publish="true" Configurations="Debug,Release" TargetFrameworks="net6.0,net472" RuntimeIdentifiers="win-x86,win-x64" />
+    <ProjectReference Include="..\TestExe\TestExe.csproj" Publish="true" Configurations="Debug,Release" TargetFrameworks="net8.0,net472" RuntimeIdentifiers="win-x86,win-x64" />
   </ItemGroup>
 
   <Import Project="$(WixTargetsPath)" />

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingExplicitTfmAndRids/Package.wxs
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingExplicitTfmAndRids/Package.wxs
@@ -11,10 +11,10 @@
                 <File Id="net472_x64" Source="!(bindpath.TestExe.net472.win_x64)\e_sqlite3.dll" />
             </Component>
             <Component Subdirectory="net6_x86">
-                <File Id="net6_x86" Source="!(bindpath.TestExe.net6.0.win_x86)\e_sqlite3.dll" />
+                <File Id="net6_x86" Source="!(bindpath.TestExe.net8.0.win_x86)\e_sqlite3.dll" />
             </Component>
             <Component Subdirectory="net6_x64">
-                <File Id="net6_x64" Source="!(bindpath.TestExe.net6.0.win_x64)\e_sqlite3.dll" />
+                <File Id="net6_x64" Source="!(bindpath.TestExe.net8.0.win_x64)\e_sqlite3.dll" />
             </Component>
 
             <!-- This is explicitly not built and causes the build to fail -->

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingExplicitTfmAndRids/PackageUsingExplicitTfmAndRids.wixproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingExplicitTfmAndRids/PackageUsingExplicitTfmAndRids.wixproj
@@ -3,7 +3,7 @@
   <Import Project="$(WixMSBuildProps)" />
 
   <ItemGroup>
-    <ProjectReference Include="..\TestExe\TestExe.csproj" Publish="true" TargetFrameworks="net6.0,net472|win-x64" RuntimeIdentifiers="win-x86,win-x64" />
+    <ProjectReference Include="..\TestExe\TestExe.csproj" Publish="true" TargetFrameworks="net8.0,net472|win-x64" RuntimeIdentifiers="win-x86,win-x64" />
   </ItemGroup>
 
   <Import Project="$(WixTargetsPath)" />

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingRids/Package.wxs
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingRids/Package.wxs
@@ -14,10 +14,10 @@
                 <File Id="net472_x64" Source="!(bindpath.TestExe.net472.win_x64)\e_sqlite3.dll" />
             </Component>
             <Component Subdirectory="net6_x86">
-                <File Id="net6_x86" Source="!(bindpath.TestExe.net6.0.win_x86)\e_sqlite3.dll" />
+                <File Id="net6_x86" Source="!(bindpath.TestExe.net8.0.win_x86)\e_sqlite3.dll" />
             </Component>
             <Component Subdirectory="net6_x64">
-                <File Id="net6_x64" Source="!(bindpath.TestExe.net6.0.win_x64)\e_sqlite3.dll" />
+                <File Id="net6_x64" Source="!(bindpath.TestExe.net8.0.win_x64)\e_sqlite3.dll" />
             </Component>
         </ComponentGroup>
     </Fragment>

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingRids/PackageUsingRids.wixproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/PackageUsingRids/PackageUsingRids.wixproj
@@ -3,7 +3,7 @@
   <Import Project="$(WixMSBuildProps)" />
 
   <ItemGroup>
-    <ProjectReference Include="..\TestExe\TestExe.csproj" Publish="true" TargetFrameworks="net6.0,net472" RuntimeIdentifiers="win-x86,win-x64" />
+    <ProjectReference Include="..\TestExe\TestExe.csproj" Publish="true" TargetFrameworks="net8.0,net472" RuntimeIdentifiers="win-x86,win-x64" />
   </ItemGroup>
 
   <Import Project="$(WixTargetsPath)" />

--- a/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/TestExe/TestExe.csproj
+++ b/src/wix/test/WixToolsetTest.Sdk/TestData/MultiTargetingWixlib/TestExe/TestExe.csproj
@@ -2,7 +2,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <RuntimeIdentifiers>win-x86;win-x64</RuntimeIdentifiers>
     <SelfContained>false</SelfContained>
   </PropertyGroup>

--- a/src/wix/wix.cmd
+++ b/src/wix/wix.cmd
@@ -38,11 +38,11 @@ msbuild -t:Publish -p:Configuration=%_C% -tl -nologo -warnaserror WixToolset.Sdk
 
 :: Test
 dotnet test ^
- %_B%\test\WixToolsetTest.Converters\net6.0\WixToolsetTest.Converters.dll ^
+ %_B%\test\WixToolsetTest.Converters\net8.0\WixToolsetTest.Converters.dll ^
  %_B%\test\WixToolsetTest.Converters.Symbolizer\net472\WixToolsetTest.Converters.Symbolizer.dll ^
- %_B%\test\WixToolsetTest.Core\net6.0\WixToolsetTest.Core.dll ^
- %_B%\test\WixToolsetTest.Core.Native\net6.0\win-x64\WixToolsetTest.Core.Native.dll ^
- %_B%\test\WixToolsetTest.CoreIntegration\net6.0\WixToolsetTest.CoreIntegration.dll ^
+ %_B%\test\WixToolsetTest.Core\net8.0\WixToolsetTest.Core.dll ^
+ %_B%\test\WixToolsetTest.Core.Native\net8.0\win-x64\WixToolsetTest.Core.Native.dll ^
+ %_B%\test\WixToolsetTest.CoreIntegration\net8.0\WixToolsetTest.CoreIntegration.dll ^
  %_B%\test\WixToolsetTest.BuildTasks\net472\WixToolsetTest.BuildTasks.dll ^
  %_B%\test\WixToolsetTest.Sdk\net472\WixToolsetTest.Sdk.dll ^
  --nologo -l "trx;LogFileName=%_L%\TestResults\wix.trx" || exit /b

--- a/src/wix/wix/wix.csproj
+++ b/src/wix/wix/wix.csproj
@@ -3,13 +3,13 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <OutputType>Exe</OutputType>
     <Description>WiX Toolset creates installation packages.</Description>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>
     <PackAsTool>true</PackAsTool>
-    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)'=='' and '$(TargetFramework)'!='net6.0' ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
+    <RuntimeIdentifiers Condition=" '$(RuntimeIdentifier)'=='' and '$(TargetFramework)'!='net8.0' ">win-x86;win-x64;win-arm64</RuntimeIdentifiers>
     <AppConfig>app.config</AppConfig>
     <ApplicationManifest>wix.exe.manifest</ApplicationManifest>
     <RollForward>Major</RollForward>


### PR DESCRIPTION
This boosts up almost all of the WiX dependencies to their latest versions.
Main issue that arose was around System.Memory.dll binding with heat.exe and the updated MSBuild libraries.
Matching the upstream MSBuild bindingRedirections for System.Memory.dll appeared to resolve this.

I've run through the various Integration tests (Burn + MSI) after the build completed successfully, all worked as expected.

None of the non net6.0 targets have been touched, so net4xx (framework) support should remain as it was.
Have also not run any 'out of flow' testing over various environments like .NET 4.7.2 etc however, so a library conflict somewhere may cause an as yet unrevealed issue.  Happy to run additional tests if there's info available for them.