### PR TITLE
EnsureTable() should bring in relevant Standard Actions which rely on the table declared

### DIFF
--- a/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerStandard.cs
+++ b/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerStandard.cs
@@ -11,6 +11,7 @@ namespace WixToolset.Data.WindowsInstaller
     {
         private static readonly Dictionary<string, WixActionSymbol> standardActionsById;
         private static readonly HashSet<string> standardActionNames;
+        private static readonly Dictionary<string, WixActionSymbol[]> standardActionsByTableName = new Dictionary<string, WixActionSymbol[]>();
 
         /// <summary>
         /// References:
@@ -368,6 +369,26 @@ namespace WixToolset.Data.WindowsInstaller
 
             standardActionNames = new HashSet<string>(standardActions.Select(a => a.Action));
             standardActionsById = standardActions.ToDictionary(a => a.Id.Id);
+
+            // Populate standard actions based on standard table names
+            standardActionsByTableName.Add("AppId", new[]
+            {
+                standardActionsById["AdvertiseExecuteSequence/RegisterClassInfo"],
+                standardActionsById["InstallExecuteSequence/UnregisterClassInfo"],
+                standardActionsById["InstallExecuteSequence/RegisterClassInfo"],
+            });
+            standardActionsByTableName.Add("AppSearch", new[]
+            {
+                standardActionsById["InstallUISequence/AppSearch"],
+                standardActionsById["InstallExecuteSequence/AppSearch"],
+            });
+            standardActionsByTableName.Add("BindImage", new[] { standardActionsById["InstallExecuteSequence/BindImage"] });
+            standardActionsByTableName.Add("RemoveFile", new[] { standardActionsById["InstallExecuteSequence/RemoveFiles"] });
+            standardActionsByTableName.Add("Registry", new[]
+            {
+                standardActionsById["InstallExecuteSequence/WriteRegistryValues"],
+                standardActionsById["InstallExecuteSequence/RemoveRegistryValues"],
+            });
         }
 
         /// <summary>
@@ -455,6 +476,14 @@ namespace WixToolset.Data.WindowsInstaller
         public static bool TryGetStandardAction(string sequenceName, string actioname, out WixActionSymbol standardAction)
         {
             return standardActionsById.TryGetValue(String.Concat(sequenceName, "/", actioname), out standardAction);
+        }
+
+        /// <summary>
+        /// Try to get standard actions associated with a table definition.
+        /// </summary>
+        public static bool TryGetTableAssociatedStandardActions(string tableName, out WixActionSymbol[] standardActions)
+        {
+            return standardActionsByTableName.TryGetValue(tableName, out standardActions);
         }
 
         /// <summary>

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/SequenceActionsCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/SequenceActionsCommand.cs
@@ -199,6 +199,21 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 overridableActionSymbols.Add(standardAction.Id.Id, standardAction);
             }
 
+            // Get the Standard Actions associated with EnsureTable symbols.
+            foreach (var table in this.Section.Symbols.OfType<WixEnsureTableSymbol>())
+            {
+                if (WindowsInstallerStandard.TryGetTableAssociatedStandardActions(table.Table, out var standardActions))
+                {
+                    foreach(var standardAction in standardActions)
+                    {
+                        if (!overridableActionSymbols.ContainsKey(standardAction.Id.Id))
+                        {
+                            overridableActionSymbols.Add(standardAction.Id.Id, standardAction);
+                        }
+                    }
+                }
+            }
+
             return overridableActionSymbols;
         }
 


### PR DESCRIPTION
The RemoveFoldersEx custom action relies upon pushing rows to the standard MSI table, and then expected the RemoveFiles standard MSI action to pick up the rows and do the removal actions. However without install files, we don't add in RemoveFiles scheduling.

This PR adds extra functionality after symbols have been resolved, where it will add in Standard Actions if they have not already been included elsewhere in the authoring.  The EnsureTable symbols are checked, and the table name used as a lookup to what Standard Actions it should directly bring in.

fixes wixtoolset/issues#8199
fixes wixtoolset/issues#8632 (in the as mentioned Standard Actions case.. not for generic custom actions)