### PR TITLE
RemoveFoldersEx test and error message correction

### DIFF
--- a/src/ext/Util/ca/RemoveFoldersEx.cpp
+++ b/src/ext/Util/ca/RemoveFoldersEx.cpp
@@ -232,7 +232,7 @@ extern "C" UINT WINAPI WixRemoveFoldersEx(
     {
         hr = S_OK;
     }
-    ExitOnFailure(hr, "Failure occured while processing Wix4RemoveFolderEx table");
+    ExitOnFailure(hr, "Failure occurred while processing Wix4RemoveFolderEx table");
 
 LExit:
 #ifndef _WIN64

--- a/src/test/msi/TestData/RemoveFolderExTests/RemoveFolderExTest/Package.wxs
+++ b/src/test/msi/TestData/RemoveFolderExTests/RemoveFolderExTest/Package.wxs
@@ -1,0 +1,15 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents">
+            <ComponentRef Id="Component1" />
+        </ComponentGroup>
+    </Fragment>
+
+    <Fragment>
+        <SetProperty Id="REMOVEFOLDEREXTESTDIR" Value="C:\RemoveFolderExTest" Sequence="execute" Before="Wix4RemoveFoldersEx_X86" />
+        <Component Id="Component1" Guid="{2D735A5F-D152-4B2E-B935-E11AD8C3FB25}">
+            <util:RemoveFolderEx Id ="RemoveAllTheFolders" On="both" Property="REMOVEFOLDEREXTESTDIR" />
+        </Component>
+    </Fragment>
+</Wix>

--- a/src/test/msi/TestData/RemoveFolderExTests/RemoveFolderExTest/RemoveFolderExTest.wixproj
+++ b/src/test/msi/TestData/RemoveFolderExTests/RemoveFolderExTest/RemoveFolderExTest.wixproj
@@ -1,0 +1,13 @@
+<!-- Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information. -->
+<Project Sdk="WixToolset.Sdk">
+  <PropertyGroup>
+    <UpgradeCode>{A75B81F4-3335-4B4D-B766-303E136ED374}</UpgradeCode>
+    <ProductComponentsRef>true</ProductComponentsRef>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="..\..\Templates\Product.wxs" Link="Product.wxs" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="WixToolset.Util.wixext" />
+  </ItemGroup>
+</Project>

--- a/src/test/msi/WixToolsetTest.MsiE2E/RemoveFolderExTests.cs
+++ b/src/test/msi/WixToolsetTest.MsiE2E/RemoveFolderExTests.cs
@@ -1,0 +1,82 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.MsiE2E;
+
+using System;
+using System.IO;
+using WixTestTools;
+using Xunit;
+using Xunit.Abstractions;
+
+public class RemoveFolderExTests : MsiE2ETests
+{
+    public RemoveFolderExTests(ITestOutputHelper testOutputHelper) : base(testOutputHelper)
+    {
+    }
+
+    [Fact]
+    public void CanRemoveFolderExOnInstallAndUninstall()
+    {
+        var removeFolderExTestDir1 =    "C:\\RemoveFolderExTest";
+        var removeFolderExTestFile1 =   Path.Combine(removeFolderExTestDir1, "testfile.txt");
+        var removeFolderExTestDir2 =    Path.Combine(removeFolderExTestDir1, "TestFolder1");
+        var removeFolderExTestFile2 =   Path.Combine(removeFolderExTestDir1, "TestFolder1", "testfile");
+
+        try
+        {
+            var product = this.CreatePackageInstaller("RemoveFolderExTest");
+
+            Directory.CreateDirectory(removeFolderExTestDir1);
+            File.Create(removeFolderExTestFile1).Dispose();
+            Directory.CreateDirectory(removeFolderExTestDir2);
+            File.Create(removeFolderExTestFile2).Dispose();
+
+            if( !Directory.Exists(removeFolderExTestDir1)
+                || !File.Exists(removeFolderExTestFile1)
+                || !Directory.Exists(removeFolderExTestDir2)
+                || !File.Exists(removeFolderExTestFile2))
+            {
+                Assert.Fail("Failed to create initial folder and file structure before install test");
+            }
+
+            product.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+
+            Assert.False(Directory.Exists(removeFolderExTestDir1), $"Failed to remove {removeFolderExTestDir1} on install");
+            Assert.False(File.Exists(removeFolderExTestFile1), $"Failed to remove {removeFolderExTestFile1} on install");
+            Assert.False(Directory.Exists(removeFolderExTestDir2), $"Failed to remove {removeFolderExTestDir2} on install");
+            Assert.False(File.Exists(removeFolderExTestFile1), $"Failed to remove {removeFolderExTestFile2} on install");
+
+
+            Directory.CreateDirectory(removeFolderExTestDir1);
+            File.Create(removeFolderExTestFile1).Dispose();
+            Directory.CreateDirectory(removeFolderExTestDir2);
+            File.Create(removeFolderExTestFile2).Dispose();
+
+            if (!Directory.Exists(removeFolderExTestDir1)
+                || !File.Exists(removeFolderExTestFile1)
+                || !Directory.Exists(removeFolderExTestDir2)
+                || !File.Exists(removeFolderExTestFile2))
+            {
+                Assert.Fail("Failed to create initial folder and file structure before uninstall test");
+            }
+
+            product.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+
+            Assert.False(Directory.Exists(removeFolderExTestDir1), $"Failed to remove {removeFolderExTestDir1} on uninstall");
+            Assert.False(File.Exists(removeFolderExTestFile1), $"Failed to remove {removeFolderExTestFile1} on uninstall");
+            Assert.False(Directory.Exists(removeFolderExTestDir2), $"Failed to remove {removeFolderExTestDir2} on uninstall");
+            Assert.False(File.Exists(removeFolderExTestFile2), $"Failed to remove {removeFolderExTestFile2} on uninstall");
+
+        }
+        finally
+        {
+            try
+            {
+                Directory.Delete(removeFolderExTestDir1, true);
+            }
+            catch
+            {
+            }
+        }
+    }
+}


### PR DESCRIPTION
Adds in an integration test case for RemoveFoldersEx Util extension.  Just a simple install / uninstall with removing files/folders.
Nothing particularly complex about it, although one file doesn't have an extension, just to confirm RemoveFiles with *.* would remove this file also.

Fixed up a typo in the error message, and split off the invalid file from the junction point error messaging (so there's no confusing message about a junction point, when the actual issue is an incorrect path).