### PR TITLE
Introduce early exception for overlength Windows Installer table name

### DIFF
--- a/src/api/wix/WixToolset.Data/ErrorMessages.cs
+++ b/src/api/wix/WixToolset.Data/ErrorMessages.cs
@@ -2266,6 +2266,11 @@ namespace WixToolset.Data
             return Message(sourceLineNumbers, Ids.IllegalAttributeWhenNested, "The File element contains an attribute '{0}' that cannot be used in a File element that is a child of a Component element.", attributeName);
         }
 
+        public static Message OverlengthTableNameInProductOrMergeModule(SourceLineNumber sourceLineNumbers, string tableName)
+        {
+            return Message(sourceLineNumbers, Ids.OverlengthTableNameInProductOrMergeModule, "The table name '{0}' is invalid because the table name exceeds 31 characters in length. For more information, see: https://learn.microsoft.com/en-au/windows/win32/msi/table-names", tableName);
+        }
+
         private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
         {
             return new Message(sourceLineNumber, MessageLevel.Error, (int)id, format, args);
@@ -2667,6 +2672,7 @@ namespace WixToolset.Data
             MsiTransactionInvalidPackage2 = 412,
             ExpectedAttributeOrElementWithOtherAttribute = 413,
             ExpectedAttributeOrElementWithoutOtherAttribute = 414,
+            OverlengthTableNameInProductOrMergeModule = 415
         }
     }
 }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/CreateWindowsInstallerDataFromIRCommand.cs
@@ -1447,6 +1447,13 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                                 this.Messaging.Write(WarningMessages.DangerousTableInMergeModule(row.SourceLineNumbers, table.Name));
                             }
                         }
+                        else if (31 < table.Name.Length)
+                        {
+                            foreach (var row in table.Rows)
+                            {
+                                this.Messaging.Write(ErrorMessages.OverlengthTableNameInProductOrMergeModule(row.SourceLineNumbers, table.Name));
+                            }
+                        }
                         break;
 
                     case OutputType.PatchCreation:
@@ -1504,6 +1511,13 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                             foreach (var row in table.Rows)
                             {
                                 this.Messaging.Write(WarningMessages.UnexpectedTableInProduct(row.SourceLineNumbers, table.Name));
+                            }
+                        }
+                        else if (31 < table.Name.Length)
+                        {
+                            foreach (var row in table.Rows)
+                            {
+                                this.Messaging.Write(ErrorMessages.OverlengthTableNameInProductOrMergeModule(row.SourceLineNumbers, table.Name));
                             }
                         }
                         break;


### PR DESCRIPTION
Introduces checks on Merge Modules and Products for overlength table names (> 31 characters).

Closes wixtoolset/issues#8645