### PR TITLE
Update thumbprints and download links to target latest .NET packages

### DIFF
--- a/src/ext/NetFx/wixlib/NetFx462.wxs
+++ b/src/ext/NetFx/wixlib/NetFx462.wxs
@@ -10,7 +10,7 @@
 
   <?define NetFx462MinRelease = 394802 ?>
   <?define NetFx462WebLink = https://go.microsoft.com/fwlink/?LinkId=780596 ?>
-  <?define NetFx462RedistLink = https://go.microsoft.com/fwlink/?LinkId=780600 ?>
+  <?define NetFx462RedistLink = https://go.microsoft.com/fwlink/?linkid=2099468 ?>
   <?define NetFx462EulaLink = https://referencesource.microsoft.com/license.html ?>
   <?define NetFx462WebId = NetFx462Web ?>
   <?define NetFx462RedistId = NetFx462Redist ?>
@@ -52,7 +52,7 @@
 
     <PackageGroup Id="$(var.NetFx462RedistId)">
       <ExePackage CacheId="$(var.NetFx462RedistId)_ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B" InstallArguments="/q /norestart /log &quot;[NetFx462FullLog].html&quot;" UninstallArguments="/uninstall /q /norestart /log &quot;[NetFx462FullLog].html&quot;" PerMachine="yes" DetectCondition="!(wix.NetFx462RedistDetectCondition)" InstallCondition="!(wix.NetFx462RedistInstallCondition)" Id="$(var.NetFx462RedistId)" Vital="yes" Permanent="yes" Protocol="netfx4" LogPathVariable="NetFx462FullLog">
-        <ExePackagePayload Name="!(wix.NetFx462RedistPackageDirectory)NDP462-KB3151800-x86-x64-AllOS-ENU.exe" DownloadUrl="$(var.NetFx462RedistLink)" ProductName="Microsoft .NET Framework 4.6.2" Description="Microsoft .NET Framework 4.6.2 Setup" CertificatePublicKey="F49F9B33E25E33CCA0BFB15A62B7C29FFAB3880B" CertificateThumbprint="ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B" Size="62000832" Version="4.6.1590.0" />
+        <ExePackagePayload Name="!(wix.NetFx462RedistPackageDirectory)NDP462-KB3151800-x86-x64-AllOS-ENU.exe" DownloadUrl="$(var.NetFx462RedistLink)" ProductName="Microsoft .NET Framework 4.6.2" Description="Microsoft .NET Framework 4.6.2 Setup" CertificatePublicKey="F49F9B33E25E33CCA0BFB15A62B7C29FFAB3880B" CertificateThumbprint="C2048FB509F1C37A8C3E9EC6648118458AA01780" Size="62024904" Version="4.6.1590.0" />
       </ExePackage>
     </PackageGroup>
   </Fragment>

--- a/src/ext/NetFx/wixlib/NetFx472.wxs
+++ b/src/ext/NetFx/wixlib/NetFx472.wxs
@@ -10,7 +10,7 @@
 
   <?define NetFx472MinRelease = 461808 ?>
   <?define NetFx472WebLink = https://go.microsoft.com/fwlink/?LinkId=863262 ?>
-  <?define NetFx472RedistLink = https://go.microsoft.com/fwlink/?LinkId=863258 ?>
+  <?define NetFx472RedistLink = https://go.microsoft.com/fwlink/?LinkId=863265 ?>
   <?define NetFx472EulaLink = https://referencesource.microsoft.com/license.html ?>
   <?define NetFx472WebId = NetFx472Web ?>
   <?define NetFx472RedistId = NetFx472Redist ?>
@@ -52,7 +52,7 @@
 
     <PackageGroup Id="$(var.NetFx472RedistId)">
       <ExePackage CacheId="$(var.NetFx472RedistId)_ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B" InstallArguments="/q /norestart /log &quot;[NetFx472RedistLog].html&quot;" PerMachine="yes" DetectCondition="!(wix.NetFx472RedistDetectCondition)" InstallCondition="!(wix.NetFx472RedistInstallCondition)" Id="$(var.NetFx472RedistId)" Vital="yes" Permanent="yes" Protocol="netfx4" LogPathVariable="NetFx472RedistLog" Cache="remove">
-        <ExePackagePayload Name="!(wix.NetFx472RedistPackageDirectory)NDP472-KB4054530-x86-x64-AllOS-ENU.exe" DownloadUrl="$(var.NetFx472RedistLink)" ProductName="Microsoft .NET Framework 4.7.2" Description="Microsoft .NET Framework 4.7.2 Setup" CertificatePublicKey="F49F9B33E25E33CCA0BFB15A62B7C29FFAB3880B" CertificateThumbprint="ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B" Size="83940592" Version="4.7.3081.0" />
+        <ExePackagePayload Name="!(wix.NetFx472RedistPackageDirectory)NDP472-KB4054530-x86-x64-AllOS-ENU.exe" DownloadUrl="$(var.NetFx472RedistLink)" ProductName="Microsoft .NET Framework 4.7.2" Description="Microsoft .NET Framework 4.7.2 Setup" CertificatePublicKey="F49F9B33E25E33CCA0BFB15A62B7C29FFAB3880B" CertificateThumbprint="C2048FB509F1C37A8C3E9EC6648118458AA01780" Size="83970736" Version="4.7.3081.0" />
       </ExePackage>
     </PackageGroup>
   </Fragment>

--- a/src/ext/NetFx/wixlib/NetFx48.wxs
+++ b/src/ext/NetFx/wixlib/NetFx48.wxs
@@ -52,7 +52,7 @@
 
     <PackageGroup Id="$(var.NetFx48RedistId)">
       <ExePackage CacheId="$(var.NetFx48RedistId)_ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B" InstallArguments="/q /norestart /log &quot;[NetFx48RedistLog].html&quot;" PerMachine="yes" DetectCondition="!(wix.NetFx48RedistDetectCondition)" InstallCondition="!(wix.NetFx48RedistInstallCondition)" Id="$(var.NetFx48RedistId)" Vital="yes" Permanent="yes" Protocol="netfx4" LogPathVariable="NetFx48RedistLog" Cache="remove">
-        <ExePackagePayload Name="!(wix.NetFx48RedistPackageDirectory)ndp48-x86-x64-allos-enu.exe" DownloadUrl="$(var.NetFx48RedistLink)" ProductName="Microsoft .NET Framework 4.8" Description="Microsoft .NET Framework 4.8 Setup" CertificatePublicKey="F49F9B33E25E33CCA0BFB15A62B7C29FFAB3880B" CertificateThumbprint="ABDCA79AF9DD48A0EA702AD45260B3C03093FB4B" Size="121307088" Version="4.8.4115.0" />
+        <ExePackagePayload Name="!(wix.NetFx48RedistPackageDirectory)ndp48-x86-x64-allos-enu.exe" DownloadUrl="$(var.NetFx48RedistLink)" ProductName="Microsoft .NET Framework 4.8" Description="Microsoft .NET Framework 4.8 Setup" CertificatePublicKey="F49F9B33E25E33CCA0BFB15A62B7C29FFAB3880B" CertificateThumbprint="C2048FB509F1C37A8C3E9EC6648118458AA01780" Size="121346568" Version="4.8.4115.0" />
       </ExePackage>
     </PackageGroup>
   </Fragment>

--- a/src/ext/NetFx/wixlib/NetFx481.wxs
+++ b/src/ext/NetFx/wixlib/NetFx481.wxs
@@ -50,9 +50,9 @@
           ProductName="Microsoft .NET Framework 4.8.1"
           Description="Microsoft .NET Framework 4.8.1 Setup"
           CertificatePublicKey="0A7D1EFF01D4EBAD21E85C51499576EBAA40E676"
-          CertificateThumbprint="AFBF0B8B6A18F7E23CCA1DDCD0AC1A55B4035173"
-          Size="1460448"
-          Version="4.8.09037.06"
+          CertificateThumbprint="72105B6D5F370B62FD5C82F1512F7AD7DEE5F2C0"
+          Size="1466664"
+          Version="4.8.09195.10"
         />
       </ExePackage>
     </PackageGroup>
@@ -93,9 +93,9 @@
           ProductName="Microsoft .NET Framework 4.8.1"
           Description="Microsoft .NET Framework 4.8.1 Setup"
           CertificatePublicKey="0A7D1EFF01D4EBAD21E85C51499576EBAA40E676"
-          CertificateThumbprint="AFBF0B8B6A18F7E23CCA1DDCD0AC1A55B4035173"
-          Size="63610344"
-          Version="4.8.09037.06"
+          CertificateThumbprint="72105B6D5F370B62FD5C82F1512F7AD7DEE5F2C0"
+          Size="77688504"
+          Version="4.8.09195.10"
           />
       </ExePackage>
     </PackageGroup>


### PR DESCRIPTION
Update thumbprints, fwlink IDs, file size and file version to match the latest .NET packages from https://dotnet.microsoft.com/en-us/download/dotnet-framework