### PR TITLE
Wix.Core.Common: Bring back '.' capability for 'loc'/'wix' variables.

### DIFF
--- a/src/wix/WixToolset.Core/Common.cs
+++ b/src/wix/WixToolset.Core/Common.cs
@@ -299,7 +299,7 @@ namespace WixToolset.Core
         /// <summary>
         /// Return an identifier based on provided file or directory name
         /// </summary>
-        /// <param name="name">File/directory name to generate identifer from</param>
+        /// <param name="name">File/directory name to generate identifier from</param>
         /// <returns>A version of the name that is a legal identifier.</returns>
         internal static string GetIdentifierFromName(string name)
         {
@@ -767,7 +767,7 @@ namespace WixToolset.Core
             var end = equalsDefaultValue == -1 ? closeParen : equalsDefaultValue;
             var secondDot = value.IndexOf('.', firstDot + 1, end - firstDot);
 
-            if (secondDot == -1)
+            if ( (secondDot == -1) || (ns != "bind") )
             {
                 name = value.Substring(firstDot + 1, end - firstDot - 1);
             }

--- a/src/wix/test/WixToolsetTest.Core/VariableResolverFixture.cs
+++ b/src/wix/test/WixToolsetTest.Core/VariableResolverFixture.cs
@@ -23,6 +23,8 @@ namespace WixToolsetTest.Core
                 { "ProductName", new BindVariable() { Id = "ProductName", Value = "Localized Product Name" } },
                 { "ProductNameEdition", new BindVariable() { Id = "ProductNameEdition", Value = "!(loc.ProductName) Enterprise Edition" } },
                 { "ProductNameEditionVersion", new BindVariable() { Id = "ProductNameEditionVersion", Value = "!(loc.ProductNameEdition) v1.2.3" } },
+                { "ProductNameEditionVersion.WithDot", new BindVariable() { Id = "ProductNameEditionVersion.WithDot", Value = "Test of localization variable with dot" } },
+                { "ProductNameEditionVersion.WithDotTest", new BindVariable() { Id = "ProductNameEditionVersion.WithDotTest", Value = "!(loc.ProductNameEditionVersion.WithDot) v1.2.3" } },
             };
 
             var localization = new Localization(0, null, "x-none", variables, new Dictionary<string, LocalizedControl>());
@@ -43,6 +45,10 @@ namespace WixToolsetTest.Core
 
             result = variableResolver.ResolveVariables(null, "Welcome to !(loc.ProductNameEditionVersion)");
             WixAssert.StringEqual("Welcome to Localized Product Name Enterprise Edition v1.2.3", result.Value);
+            Assert.True(result.UpdatedValue);
+
+            result = variableResolver.ResolveVariables(null, "Welcome to !(loc.ProductNameEditionVersion.WithDotTest)");
+            WixAssert.StringEqual("Welcome to Test of localization variable with dot v1.2.3", result.Value);
             Assert.True(result.UpdatedValue);
 
             result = variableResolver.ResolveVariables(null, "Welcome to !(bind.property.ProductVersion)");


### PR DESCRIPTION
WiX v3 allowed for dots '.' in localization variables, bring this behaviour back.

Add test for Localization variable with multiple dots '.' within it.
Modify Common.TryParseWixVariable to only look for subsequent dots in the bind variables, the others (wix/loc) will just be considered as names that include dots.
Also fixed up typo of 'identifier'.

fixes wixtoolset/issues#8713