### PR TITLE
Use an unnamed bindpath as a default root for...

### DIFF
--- a/src/wix/WixToolset.Core/ExtensibilityServices/FileResolver.cs
+++ b/src/wix/WixToolset.Core/ExtensibilityServices/FileResolver.cs
@@ -90,7 +90,7 @@ namespace WixToolset.Core.ExtensibilityServices
                     if (-1 != closeParen)
                     {
                         bindName = source.Substring(BindPathOpenString.Length, closeParen - BindPathOpenString.Length);
-                        path = source.Substring(BindPathOpenString.Length + bindName.Length + 1); // +1 for the closing brace.
+                        path = source.Substring(BindPathOpenString.Length + bindName.Length + 1); // +1 for the closing paren.
                         path = path.TrimStart('\\'); // remove starting '\\' char so the path doesn't look rooted.
                     }
                 }

--- a/src/wix/WixToolset.Core/HarvestFilesCommand.cs
+++ b/src/wix/WixToolset.Core/HarvestFilesCommand.cs
@@ -195,14 +195,16 @@ namespace WixToolset.Core
                 if (-1 != closeParen)
                 {
                     bindName = source.Substring(BindPathOpenString.Length, closeParen - BindPathOpenString.Length);
-                    path = source.Substring(BindPathOpenString.Length + bindName.Length + 1); // +1 for the closing brace.
+                    path = source.Substring(BindPathOpenString.Length + bindName.Length + 1); // +1 for the closing paren.
                     path = path.TrimStart('\\'); // remove starting '\\' char so the path doesn't look rooted.
                 }
             }
 
             if (String.IsNullOrEmpty(bindName))
             {
-                resultingDirectories.Add(path);
+                var unnamedBindPath = this.Context.BindPaths.SingleOrDefault(bp => bp.Name == null)?.Path;
+
+                resultingDirectories.Add(unnamedBindPath is null ? path : Path.Combine(unnamedBindPath, path));
             }
             else
             {

--- a/src/wix/test/WixToolsetTest.CoreIntegration/HarvestFilesFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/HarvestFilesFixture.cs
@@ -238,7 +238,7 @@ namespace WixToolsetTest.CoreIntegration
         }
 
         [Fact]
-        public void CanHarvestFilesWithBindPaths()
+        public void CanHarvestFilesWithNamedBindPaths()
         {
             var expected = new[]
             {
@@ -254,6 +254,27 @@ namespace WixToolsetTest.CoreIntegration
             };
 
             Build("BindPaths.wxs", (msiPath, _) => AssertFileIdsAndTargetPaths(msiPath, expected));
+        }
+
+        [Fact]
+        public void CanHarvestFilesWithUnnamedBindPaths()
+        {
+            var expected = new[]
+            {
+                @"flsNNsTNrgmjASmTBbP.45J1F50dEc=PFiles\HarvestedFiles\test1.txt",
+                @"flsASLR5pHQzLmWRE.Snra7ndH7sIA=PFiles\HarvestedFiles\test2.txt",
+                @"flsTZFPiMHb.qfUxdGKQYrnXOhZ.8M=PFiles\HarvestedFiles\files1_sub1\test10.txt",
+                @"flsLGcTTZPIU3ELiWybqnm.PQ0Ih_g=PFiles\HarvestedFiles\files1_sub1\files1_sub2\test120.txt",
+                @"fls1Jx2Y9Vea_.WZBH_h2e79arvDRU=PFiles\HarvestedFiles\test3.txt",
+                @"flsJ9gNxWaau2X3ufphQuCV9WwAgcw=PFiles\HarvestedFiles\test4.txt",
+                @"flswcmX9dpMQytmD_5QA5aJ5szoQVA=PFiles\HarvestedFiles\files2_sub2\test20.txt",
+                @"flskKeCKFUtCYMuvw564rgPLJmyBx0=PFiles\HarvestedFiles\files2_sub2\test21.txt",
+                @"fls2agLZFnQwjoijShwT9Z0RwHyGrI=PFiles\HarvestedFiles\files2_sub3\FileName.Extension",
+                @"fls9UMOE.TOv61JuYF8IhvCKb8eous=PFiles\HarvestedFiles\namedfile.txt",
+                @"flsu53T_9CcaBegDflAImGHTajDbJ0=PFiles\HarvestedFiles\unnamedfile.txt",
+            };
+
+            Build("BindPathsUnnamed.wxs", (msiPath, _) => AssertFileIdsAndTargetPaths(msiPath, expected), addUnnamedBindPath: true);
         }
 
         [Fact]
@@ -325,7 +346,7 @@ namespace WixToolsetTest.CoreIntegration
             Assert.Equal(sortedExpected, actual);
         }
 
-        private static void Build(string file, Action<string, WixRunnerResult> tester, bool isPackage = true, bool warningsAsErrors = true, params string[] additionalCommandLineArguments)
+        private static void Build(string file, Action<string, WixRunnerResult> tester, bool isPackage = true, bool warningsAsErrors = true, bool addUnnamedBindPath = false, params string[] additionalCommandLineArguments)
         {
             var folder = TestData.Get("TestData", "HarvestFiles");
 
@@ -341,11 +362,16 @@ namespace WixToolsetTest.CoreIntegration
                     "build",
                     Path.Combine(folder, file),
                     "-intermediateFolder", intermediateFolder,
-                    "-bindpath", folder,
                     "-bindpath", @$"ToBeHarvested={folder}\files1",
                     "-bindpath", @$"ToBeHarvested={folder}\files2",
                     "-o", msiPath,
                 };
+
+                if (addUnnamedBindPath)
+                {
+                    arguments.Add("-bindpath");
+                    arguments.Add(Path.Combine(folder, "unnamedbindpath"));
+                }
 
                 if (additionalCommandLineArguments.Length > 0)
                 {

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/BindPathsUnnamed.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/BindPathsUnnamed.wxs
@@ -1,0 +1,19 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Name="HarvestedFiles" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+        <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
+
+        <Feature Id="ProductFeature">
+            <ComponentGroupRef Id="Files" />
+        </Feature>
+
+        <ComponentGroup Id="Files" Directory="ProgramFilesFolder" Subdirectory="HarvestedFiles">
+            <Files Include="!(bindpath.ToBeHarvested)\**">
+                <Exclude Files="!(bindpath.ToBeHarvested)\notatest.txt" />
+                <Exclude Files="!(bindpath.ToBeHarvested)\**\pleasedontincludeme.dat" />
+            </Files>
+
+            <!-- Include everything from the unnamed bindpath too. -->
+            <Files Include="**" />
+        </ComponentGroup>
+    </Package>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/unnamedbindpath/namedfile.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/unnamedbindpath/namedfile.txt
@@ -1,0 +1,1 @@
+This is test.txt.

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/unnamedbindpath/unnamedfile.txt
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/unnamedbindpath/unnamedfile.txt
@@ -1,0 +1,1 @@
+This is test.txt.


### PR DESCRIPTION
...harvesting files (as documented).

- Fixes https://github.com/wixtoolset/issues/issues/8585