### PR TITLE
Add overloads to support create-only Wixouts.

### DIFF
--- a/src/api/wix/WixToolset.Data/Intermediate.cs
+++ b/src/api/wix/WixToolset.Data/Intermediate.cs
@@ -247,6 +247,20 @@ namespace WixToolset.Data
         }
 
         /// <summary>
+        /// Saves an intermediate that can only be written to to a path on disk.
+        /// </summary>
+        /// <param name="path">Path to save intermediate file to disk.</param>
+        public void SaveNew(string path)
+        {
+            Directory.CreateDirectory(Path.GetDirectoryName(Path.GetFullPath(path)));
+
+            using (var wixout = WixOutput.CreateNew(path))
+            {
+                this.Save(wixout);
+            }
+        }
+
+        /// <summary>
         /// Saves an intermediate to a WixOutput.
         /// </summary>
         /// <param name="wixout">Destination to save.</param>

--- a/src/api/wix/WixToolset.Data/WixOutput.cs
+++ b/src/api/wix/WixToolset.Data/WixOutput.cs
@@ -25,7 +25,7 @@ namespace WixToolset.Data
         }
 
         /// <summary>
-        /// 
+        ///
         /// </summary>
         public Uri Uri { get; }
 
@@ -189,7 +189,10 @@ namespace WixToolset.Data
         /// <returns>Stream to the data of the file.</returns>
         public Stream CreateDataStream(string name)
         {
-            this.DeleteExistingEntry(name);
+            if (this.archive.Mode == ZipArchiveMode.Update)
+            {
+                this.DeleteExistingEntry(name);
+            }
 
             var entry = this.archive.CreateEntry(name);
 
@@ -203,7 +206,10 @@ namespace WixToolset.Data
         /// <param name="path">Path to file on disk to include in the output.</param>
         public void ImportDataStream(string name, string path)
         {
-            this.DeleteExistingEntry(name);
+            if (this.archive.Mode == ZipArchiveMode.Update)
+            {
+                this.DeleteExistingEntry(name);
+            }
 
             this.archive.CreateEntryFromFile(path, name, System.IO.Compression.CompressionLevel.Optimal);
         }
@@ -238,6 +244,26 @@ namespace WixToolset.Data
             {
                 return streamReader.ReadToEnd();
             }
+        }
+
+        /// <summary>
+        /// Creates a new file structure on disk that can only be written to.
+        /// </summary>
+        /// <param name="path">Path to write file structure to.</param>
+        /// <returns>Newly created <c>WixOutput</c>.</returns>
+        internal static WixOutput CreateNew(string path)
+        {
+            var fullPath = Path.GetFullPath(path);
+
+            Directory.CreateDirectory(Path.GetDirectoryName(fullPath));
+
+            var uri = new Uri(fullPath);
+
+            var stream = File.Create(path);
+
+            var archive = new ZipArchive(stream, ZipArchiveMode.Create, leaveOpen: true);
+
+            return new WixOutput(uri, archive, stream);
         }
 
         /// <summary>

--- a/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
+++ b/src/wix/WixToolset.Core/CommandLine/BuildCommand.cs
@@ -248,7 +248,7 @@ namespace WixToolset.Core.CommandLine
 
                 if (!this.Messaging.EncounteredError)
                 {
-                    result.Library.Save(outputPath);
+                    result.Library.SaveNew(outputPath);
 
                     this.LayoutFiles(result.TrackedFiles, null, cancellationToken);
                 }


### PR DESCRIPTION
This prevents the .NET ZipArchive (and friends) from keeping the whole thing in memory, to support updating when we don't need to update the Wixout when building a binary Wixlib.