### PR TITLE
Add bal:DisplayFilesInUseDialogCondition attribute to disable "Files In Use"

### DIFF
--- a/src/api/burn/WixToolset.BootstrapperApplicationApi/IPackageInfo.cs
+++ b/src/api/burn/WixToolset.BootstrapperApplicationApi/IPackageInfo.cs
@@ -28,6 +28,11 @@ namespace WixToolset.BootstrapperApplicationApi
         string DisplayInternalUICondition { get; }
 
         /// <summary>
+        /// The authored bal:DisplayFilesInUseDialogCondition.
+        /// </summary>
+        string DisplayFilesInUseDialogCondition { get; }
+
+        /// <summary>
         /// The package's display name.
         /// </summary>
         string DisplayName { get; }

--- a/src/api/burn/WixToolset.BootstrapperApplicationApi/PackageInfo.cs
+++ b/src/api/burn/WixToolset.BootstrapperApplicationApi/PackageInfo.cs
@@ -121,6 +121,9 @@ namespace WixToolset.BootstrapperApplicationApi
         public string DisplayInternalUICondition { get; internal set; }
 
         /// <inheritdoc/>
+        public string DisplayFilesInUseDialogCondition { get; internal set; }
+
+        /// <inheritdoc/>
         public string ProductCode { get; internal set; }
 
         /// <inheritdoc/>
@@ -363,6 +366,7 @@ namespace WixToolset.BootstrapperApplicationApi
                 var package = (PackageInfo)ipackage;
 
                 package.DisplayInternalUICondition = BootstrapperApplicationData.GetAttribute(node, "DisplayInternalUICondition");
+                package.DisplayFilesInUseDialogCondition = BootstrapperApplicationData.GetAttribute(node, "DisplayFilesInUseDialogCondition");
             }
 
             nodes = root.Select("/p:BootstrapperApplicationData/p:WixPrereqInformation", namespaceManager);

--- a/src/api/burn/balutil/balinfo.cpp
+++ b/src/api/burn/balutil/balinfo.cpp
@@ -291,6 +291,7 @@ DAPI_(void) BalInfoUninitialize(
         ReleaseStr(pBundle->packages.rgPackages[i].sczDescription);
         ReleaseStr(pBundle->packages.rgPackages[i].sczId);
         ReleaseStr(pBundle->packages.rgPackages[i].sczDisplayInternalUICondition);
+        ReleaseStr(pBundle->packages.rgPackages[i].sczDisplayFilesInUseDialogCondition);
         ReleaseStr(pBundle->packages.rgPackages[i].sczProductCode);
         ReleaseStr(pBundle->packages.rgPackages[i].sczUpgradeCode);
         ReleaseStr(pBundle->packages.rgPackages[i].sczVersion);
@@ -516,6 +517,9 @@ static HRESULT ParseBalPackageInfoFromXml(
 
         hr = XmlGetAttributeEx(pNode, L"DisplayInternalUICondition", &pPackage->sczDisplayInternalUICondition);
         ExitOnOptionalXmlQueryFailure(hr, fXmlFound, "Failed to get DisplayInternalUICondition setting for package.");
+
+        hr = XmlGetAttributeEx(pNode, L"DisplayFilesInUseDialogCondition", &pPackage->sczDisplayFilesInUseDialogCondition);
+        ExitOnOptionalXmlQueryFailure(hr, fXmlFound, "Failed to get DisplayFilesInUseDialogCondition setting for package.");
 
         hr = XmlGetAttributeEx(pNode, L"PrimaryPackageType", &scz);
         ExitOnOptionalXmlQueryFailure(hr, fXmlFound, "Failed to get PrimaryPackageType setting for package.");

--- a/src/api/burn/balutil/inc/balinfo.h
+++ b/src/api/burn/balutil/inc/balinfo.h
@@ -54,6 +54,7 @@ typedef struct _BAL_INFO_PACKAGE
     BOOL fPermanent;
     BOOL fVital;
     LPWSTR sczDisplayInternalUICondition;
+    LPWSTR sczDisplayFilesInUseDialogCondition;
     LPWSTR sczProductCode;
     LPWSTR sczUpgradeCode;
     LPWSTR sczVersion;

--- a/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/BalExtensionFixture.cs
+++ b/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/BalExtensionFixture.cs
@@ -52,6 +52,44 @@ namespace WixToolsetTest.BootstrapperApplications
         }
 
         [Fact]
+        public void CanBuildUsingDisplayFilesInUseDialogCondition()
+        {
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var bundleFile = Path.Combine(baseFolder, "bin", "test.exe");
+                var bundleSourceFolder = TestData.Get(@"TestData\WixStdBa");
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var baFolderPath = Path.Combine(baseFolder, "ba");
+                var extractFolderPath = Path.Combine(baseFolder, "extract");
+
+                var compileResult = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(bundleSourceFolder, "DisplayFilesInUseDialogConditionBundle.wxs"),
+                    "-ext", TestData.Get(@"WixToolset.BootstrapperApplications.wixext.dll"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-bindpath", Path.Combine(bundleSourceFolder, "data"),
+                    "-o", bundleFile,
+                });
+                compileResult.AssertSuccess();
+
+                Assert.True(File.Exists(bundleFile));
+
+                var extractResult = BundleExtractor.ExtractBAContainer(null, bundleFile, baFolderPath, extractFolderPath);
+                extractResult.AssertSuccess();
+
+                var balPackageInfos = extractResult.GetBADataTestXmlLines("/ba:BootstrapperApplicationData/ba:WixBalPackageInfo");
+                WixAssert.CompareLineByLine(new string[]
+                {
+                    "<WixBalPackageInfo PackageId='test.msi' DisplayFilesInUseDialogCondition='1' />",
+                }, balPackageInfos);
+
+                Assert.True(File.Exists(Path.Combine(baFolderPath, "thm.wxl")));
+            }
+        }
+
+        [Fact]
         public void CanBuildUsingOverridable()
         {
             using (var fs = new DisposableFileSystem())
@@ -253,6 +291,7 @@ namespace WixToolsetTest.BootstrapperApplications
                 {
                     "bal:Condition/@Condition contains the built-in Variable 'WixBundleAction', which is not available when it is evaluated. (Unavailable Variables are: 'WixBundleAction'.). Rewrite the condition to avoid Variables that are never valid during its evaluation.",
                     "Overridable variable 'TEST1' collides with 'Test1' with Bundle/@CommandLineVariables value 'caseInsensitive'.",
+                    "The *Package/@bal:DisplayFilesInUseDialogCondition attribute's value '=' is not a valid bundle condition.",
                     "The *Package/@bal:DisplayInternalUICondition attribute's value '=' is not a valid bundle condition.",
                     "The location of the Variable related to the previous error.",
                 }, messages.ToArray());

--- a/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/InternalUIBAFixture.cs
+++ b/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/InternalUIBAFixture.cs
@@ -167,6 +167,7 @@ namespace WixToolsetTest.BootstrapperApplications
                     "WixInternalUIBootstrapperApplication does not support the value of 'force' for Cache on prereq packages. Prereq packages are only cached when they need to be installed.",
                     "WixInternalUIBootstrapperApplication ignores InstallCondition for the primary package so that the MSI UI is always shown.",
                     "WixInternalUIBootstrapperApplication ignores DisplayInternalUICondition for the primary package so that the MSI UI is always shown.",
+                    "WixInternalUIBootstrapperApplication ignores DisplayFilesInUseDialogCondition for the primary package so that the MSI UI is always shown.",
                     "When using WixInternalUIBootstrapperApplication, all prereq packages should be before the primary package in the chain. The prereq packages are always installed before the primary package.",
                 }, compileResult.Messages.Select(m => m.ToString()).ToArray());
 
@@ -180,7 +181,7 @@ namespace WixToolsetTest.BootstrapperApplications
                 var balPackageInfos = extractResult.GetBADataTestXmlLines("/ba:BootstrapperApplicationData/ba:WixBalPackageInfo");
                 WixAssert.CompareLineByLine(new string[]
                 {
-                    "<WixBalPackageInfo PackageId='test.msi' DisplayInternalUICondition='DISPLAYTEST' PrimaryPackageType='default' />",
+                    "<WixBalPackageInfo PackageId='test.msi' DisplayInternalUICondition='DISPLAYTEST' DisplayFilesInUseDialogCondition='DISPLAYTEST' PrimaryPackageType='default' />",
                 }, balPackageInfos);
 
                 var mbaPrereqInfos = extractResult.GetBADataTestXmlLines("/ba:BootstrapperApplicationData/ba:WixPrereqInformation");

--- a/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/TestData/Overridable/WrongCaseBundle.wxs
+++ b/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/TestData/Overridable/WrongCaseBundle.wxs
@@ -9,7 +9,7 @@
         <Variable Name="TEST1" bal:Overridable="yes" />
         <Chain>
             <ExePackage Permanent="yes" DetectCondition="none" SourceFile="runtimes\win-x86\native\wixnative.exe" />
-            <MsiPackage SourceFile="test.msi" bal:DisplayInternalUICondition="!(loc.NonsensePlanCondition)" />
+            <MsiPackage SourceFile="test.msi" bal:DisplayInternalUICondition="!(loc.NonsensePlanCondition)" bal:DisplayFilesInUseDialogCondition="!(loc.NonsensePlanCondition)" />
         </Chain>
         <bal:Condition Condition="!(loc.NonsenseDetectCondition)" Message="Unsupported" />
     </Bundle>

--- a/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/TestData/WixIuiBa/IuibaWarnings.wxs
+++ b/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/TestData/WixIuiBa/IuibaWarnings.wxs
@@ -6,7 +6,7 @@
             <bal:WixInternalUIBootstrapperApplication />
         </BootstrapperApplication>
         <Chain>
-            <MsiPackage SourceFile="test.msi" InstallCondition="INSTALLTEST" bal:DisplayInternalUICondition="DISPLAYTEST" />
+            <MsiPackage SourceFile="test.msi" InstallCondition="INSTALLTEST" bal:DisplayInternalUICondition="DISPLAYTEST" bal:DisplayFilesInUseDialogCondition="DISPLAYTEST" />
             <ExePackage Permanent="yes" DetectCondition="none" SourceFile="runtimes\win-x86\native\wixnative.exe" Cache="force" />
         </Chain>
     </Bundle>

--- a/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/TestData/WixStdBa/DisplayFilesInUseDialogConditionBundle.wxs
+++ b/src/ext/Bal/test/WixToolsetTest.BootstrapperApplications/TestData/WixStdBa/DisplayFilesInUseDialogConditionBundle.wxs
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
+     xmlns:bal="http://wixtoolset.org/schemas/v4/wxs/bal">
+    <Bundle Name="WixStdBa" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="75D5D534-E177-4689-AAE9-CAC1C39002C2">
+        <BootstrapperApplication>
+            <bal:WixStandardBootstrapperApplication LicenseUrl="http://wixtoolset.org/about/license/" Theme="hyperlinkLicense" />
+        </BootstrapperApplication>
+        <Chain>
+            <MsiPackage SourceFile="test.msi" bal:DisplayFilesInUseDialogCondition="1" />
+        </Chain>
+    </Bundle>
+</Wix>

--- a/src/ext/Bal/wixext/BalBurnBackendExtension.cs
+++ b/src/ext/Bal/wixext/BalBurnBackendExtension.cs
@@ -51,6 +51,11 @@ namespace WixToolset.BootstrapperApplications
                         writer.WriteAttributeString("DisplayInternalUICondition", balPackageInfoSymbol.DisplayInternalUICondition);
                     }
 
+                    if (balPackageInfoSymbol.DisplayFilesInUseDialogCondition != null)
+                    {
+                        writer.WriteAttributeString("DisplayFilesInUseDialogCondition", balPackageInfoSymbol.DisplayFilesInUseDialogCondition);
+                    }
+
                     if (balPackageInfoSymbol.PrimaryPackageType != BalPrimaryPackageType.None)
                     {
                         writer.WriteAttributeString("PrimaryPackageType", balPackageInfoSymbol.PrimaryPackageType.ToString().ToLower());
@@ -104,6 +109,7 @@ namespace WixToolset.BootstrapperApplications
 
             this.VerifyBalConditions(section);
             this.VerifyDisplayInternalUICondition(section);
+            this.VerifyDisplayFilesInUseDialogCondition(section);
             this.VerifyOverridableVariables(section);
 
             var balBaSymbol = section.Symbols.OfType<WixBalBootstrapperApplicationSymbol>().SingleOrDefault();
@@ -191,6 +197,17 @@ namespace WixToolset.BootstrapperApplications
                 if (balPackageInfoSymbol.DisplayInternalUICondition != null)
                 {
                     this.BackendHelper.ValidateBundleCondition(balPackageInfoSymbol.SourceLineNumbers, "*Package", "bal:DisplayInternalUICondition", balPackageInfoSymbol.DisplayInternalUICondition, BundleConditionPhase.Plan);
+                }
+            }
+        }
+
+        private void VerifyDisplayFilesInUseDialogCondition(IntermediateSection section)
+        {
+            foreach (var balPackageInfoSymbol in section.Symbols.OfType<WixBalPackageInfoSymbol>().ToList())
+            {
+                if (balPackageInfoSymbol.DisplayFilesInUseDialogCondition != null)
+                {
+                    this.BackendHelper.ValidateBundleCondition(balPackageInfoSymbol.SourceLineNumbers, "*Package", "bal:DisplayFilesInUseDialogCondition", balPackageInfoSymbol.DisplayFilesInUseDialogCondition, BundleConditionPhase.Plan);
                 }
             }
         }
@@ -419,6 +436,11 @@ namespace WixToolset.BootstrapperApplications
             if (balPackageInfoSymbol.DisplayInternalUICondition != null)
             {
                 this.Messaging.Write(BalWarnings.IuibaPrimaryPackageDisplayInternalUICondition(packageSymbol.SourceLineNumbers));
+            }
+
+            if (balPackageInfoSymbol.DisplayFilesInUseDialogCondition != null)
+            {
+                this.Messaging.Write(BalWarnings.IuibaPrimaryPackageDisplayFilesInUseDialogCondition(packageSymbol.SourceLineNumbers));
             }
         }
 

--- a/src/ext/Bal/wixext/BalCompiler.cs
+++ b/src/ext/Bal/wixext/BalCompiler.cs
@@ -200,6 +200,20 @@ namespace WixToolset.BootstrapperApplications
                                         break;
                                 }
                                 break;
+                            case "DisplayFilesInUseDialogCondition":
+                                switch (parentElement.Name.LocalName)
+                                {
+                                    case "MsiPackage":
+                                    case "MspPackage":
+                                        var displayFilesInUseDialogCondition = this.ParseHelper.GetAttributeValue(sourceLineNumbers, attribute);
+                                        var packageInfo = this.GetBalPackageInfoSymbol(section, sourceLineNumbers, packageId);
+                                        packageInfo.DisplayFilesInUseDialogCondition = displayFilesInUseDialogCondition;
+                                        break;
+                                    default:
+                                        this.ParseHelper.UnexpectedAttribute(parentElement, attribute);
+                                        break;
+                                }
+                                break;
                             case "PrimaryPackageType":
                             {
                                 var primaryPackageType = BalPrimaryPackageType.None;

--- a/src/ext/Bal/wixext/BalWarnings.cs
+++ b/src/ext/Bal/wixext/BalWarnings.cs
@@ -23,6 +23,11 @@ namespace WixToolset.BootstrapperApplications
             return Message(sourceLineNumbers, Ids.IuibaPrimaryPackageDisplayInternalUICondition, "WixInternalUIBootstrapperApplication ignores DisplayInternalUICondition for the primary package so that the MSI UI is always shown.");
         }
 
+        public static Message IuibaPrimaryPackageDisplayFilesInUseDialogCondition(SourceLineNumber sourceLineNumbers)
+        {
+            return Message(sourceLineNumbers, Ids.IuibaPrimaryPackageDisplayFilesInUseDialogCondition, "WixInternalUIBootstrapperApplication ignores DisplayFilesInUseDialogCondition for the primary package so that the MSI UI is always shown.");
+        }
+
         public static Message IuibaPrimaryPackageInstallCondition(SourceLineNumber sourceLineNumbers)
         {
             return Message(sourceLineNumbers, Ids.IuibaPrimaryPackageInstallCondition, "WixInternalUIBootstrapperApplication ignores InstallCondition for the primary package so that the MSI UI is always shown.");
@@ -56,6 +61,7 @@ namespace WixToolset.BootstrapperApplications
             IuibaPrimaryPackageDisplayInternalUICondition = 6504,
             IuibaPrereqPackageAfterPrimaryPackage = 6505,
             DeprecatedBAFactoryAssemblyAttribute = 6506,
+            IuibaPrimaryPackageDisplayFilesInUseDialogCondition = 6507,
         }
     }
 }

--- a/src/ext/Bal/wixext/Symbols/WixBalPackageInfoSymbol.cs
+++ b/src/ext/Bal/wixext/Symbols/WixBalPackageInfoSymbol.cs
@@ -13,6 +13,7 @@ namespace WixToolset.BootstrapperApplications
             {
                 new IntermediateFieldDefinition(nameof(WixBalPackageInfoSymbolFields.PackageId), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(WixBalPackageInfoSymbolFields.DisplayInternalUICondition), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(WixBalPackageInfoSymbolFields.DisplayFilesInUseDialogCondition), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(WixBalPackageInfoSymbolFields.PrimaryPackageType), IntermediateFieldType.Number),
             },
             typeof(WixBalPackageInfoSymbol));
@@ -27,6 +28,7 @@ namespace WixToolset.BootstrapperApplications.Symbols
     {
         PackageId,
         DisplayInternalUICondition,
+        DisplayFilesInUseDialogCondition,
         PrimaryPackageType,
     }
 
@@ -61,6 +63,12 @@ namespace WixToolset.BootstrapperApplications.Symbols
         {
             get => this.Fields[(int)WixBalPackageInfoSymbolFields.DisplayInternalUICondition].AsString();
             set => this.Set((int)WixBalPackageInfoSymbolFields.DisplayInternalUICondition, value);
+        }
+
+        public string DisplayFilesInUseDialogCondition
+        {
+            get => this.Fields[(int)WixBalPackageInfoSymbolFields.DisplayFilesInUseDialogCondition].AsString();
+            set => this.Set((int)WixBalPackageInfoSymbolFields.DisplayFilesInUseDialogCondition, value);
         }
 
         public BalPrimaryPackageType PrimaryPackageType


### PR DESCRIPTION
We develop an application with a DLL that is loaded into many processes, largely outside of our control.  It is confusing for our users when they are prompted to close these seemingly unrelated applications when we update the DLL.  Updating the DLL requires a reboot independently of any files being in use anyway, so hiding the "Files In Use" dialog is a nice solution for us.

There are other examples of people wanting to disable the "Files In Use" dialog:

- [DisplayInternalUICondition doesn't work correctly Wix 4](https://stackoverflow.com/questions/78896314/displayinternaluicondition-doesnt-work-correctly-wix-4)
- [WiX: Avoid showing files-in-use dialog and just prompt for reboot at end of install](https://stackoverflow.com/questions/15981411/wix-avoid-showing-files-in-use-dialog-and-just-prompt-for-reboot-at-end-of-inst)
- [Windows Installer-Avoid FileinUse dialog box when Installing a package](https://stackoverflow.com/questions/50917062/windows-installer-avoid-fileinuse-dialog-box-when-installing-a-package?rq=3)
- [How to suppress a dialog](https://stackoverflow.com/questions/29103629/how-to-suppress-a-dialog)

Add `bal:DisplayFilesInUseDialogCondition`, similar to `bal::DisplayInternalUICondition`, to be added to `MsiPackage` elements to control the display of "Files In Use" in `WixStandardBoostrapperApplication`.

For example:

~~~xml
<Bundle Name="...">
  <!-- ... -->
  <Chain>
    <MsiPackage 
      Id="..."
      SourceFile="..."
      bal:DisplayFilesInUseDialogCondition="no"
    />
  </Chain>
</Bundle>
~~~