### PR TITLE
Magicked files in modules need complex references.

### DIFF
--- a/src/api/wix/WixToolset.Data/Symbols/HarvestFilesSymbol.cs
+++ b/src/api/wix/WixToolset.Data/Symbols/HarvestFilesSymbol.cs
@@ -16,6 +16,7 @@ namespace WixToolset.Data
                 new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.ComplexReferenceParentType), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.ParentId), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.SourcePath), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(HarvestFilesSymbolFields.ModuleLanguage), IntermediateFieldType.String),
             },
             typeof(HarvestFilesSymbol));
     }
@@ -31,6 +32,7 @@ namespace WixToolset.Data.Symbols
         ComplexReferenceParentType,
         ParentId,
         SourcePath,
+        ModuleLanguage,
     }
 
     public class HarvestFilesSymbol : IntermediateSymbol
@@ -79,6 +81,12 @@ namespace WixToolset.Data.Symbols
         {
             get => (string)this.Fields[(int)HarvestFilesSymbolFields.SourcePath];
             set => this.Set((int)HarvestFilesSymbolFields.SourcePath, value);
+        }
+
+        public string ModuleLanguage
+        {
+            get => (string)this.Fields[(int)HarvestFilesSymbolFields.ModuleLanguage];
+            set => this.Set((int)HarvestFilesSymbolFields.ModuleLanguage, value);
         }
     }
 }

--- a/src/wix/WixToolset.Core/Compiler.cs
+++ b/src/wix/WixToolset.Core/Compiler.cs
@@ -5689,7 +5689,12 @@ namespace WixToolset.Core
 
                 this.ParseFileElementChildren(node, fileSymbol, keyPath, win64);
 
-                if (ComplexReferenceParentType.Unknown != parentType && null != parentId) // if parent was provided, add a complex reference to that.
+                // if this is a module, automatically add this component to the references to ensure it gets in the ModuleComponents table
+                if (this.compilingModule)
+                {
+                    this.Core.CreateComplexReference(sourceLineNumbers, ComplexReferenceParentType.Module, this.activeName, this.activeLanguage, ComplexReferenceChildType.Component, fileSymbol.Id.Id, false);
+                }
+                else if (ComplexReferenceParentType.Unknown != parentType && null != parentId) // if parent was provided, add a complex reference to that.
                 {
                     // If the naked file's component is defined directly under a feature, then mark the complex reference primary.
                     this.Core.CreateComplexReference(sourceLineNumbers, parentType, parentId, null, ComplexReferenceChildType.Component, fileSymbol.Id.Id, ComplexReferenceParentType.Feature == parentType);
@@ -5790,6 +5795,7 @@ namespace WixToolset.Core
                 ComplexReferenceParentType = parentType.ToString(),
                 ParentId = parentId,
                 SourcePath = sourcePath,
+                ModuleLanguage = this.compilingModule ? this.activeLanguage : null,
             });
         }
 

--- a/src/wix/WixToolset.Core/HarvestFilesCommand.cs
+++ b/src/wix/WixToolset.Core/HarvestFilesCommand.cs
@@ -107,10 +107,15 @@ namespace WixToolset.Core
                             Win64 = this.Context.Platform == Platform.ARM64 || this.Context.Platform == Platform.X64,
                         });
 
-                        if (Enum.TryParse<ComplexReferenceParentType>(harvestFile.ComplexReferenceParentType, out var parentType)
+                        // if this is a module, automatically add this component to the references to ensure it gets in the ModuleComponents table
+                        if (!String.IsNullOrEmpty(harvestFile.ModuleLanguage))
+                        {
+                            this.ParseHelper.CreateComplexReference(section, harvestFile.SourceLineNumbers, ComplexReferenceParentType.Module, harvestFile.ParentId, harvestFile.ModuleLanguage, ComplexReferenceChildType.Component, id.Id, false);
+                        }
+                        else if (Enum.TryParse<ComplexReferenceParentType>(harvestFile.ComplexReferenceParentType, out var parentType)
                             && ComplexReferenceParentType.Unknown != parentType && null != harvestFile.ParentId)
                         {
-                            // If the parent was provided, add a complex reference to that, and, if 
+                            // If the parent was provided, add a complex reference to that, and, if
                             // the Files is under a feature, then mark the complex reference primary.
                             this.ParseHelper.CreateComplexReference(section, harvestFile.SourceLineNumbers, parentType, harvestFile.ParentId, null, ComplexReferenceChildType.Component, id.Id, ComplexReferenceParentType.Feature == parentType);
                         }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/NakedFileFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/NakedFileFixture.cs
@@ -2,6 +2,7 @@
 
 namespace WixToolsetTest.CoreIntegration
 {
+    using System.Collections.Generic;
     using System.Data;
     using System.IO;
     using System.Linq;
@@ -82,6 +83,14 @@ namespace WixToolsetTest.CoreIntegration
             var rows = BuildAndQueryComponentAndFileTables("Module.wxs", isPackage: false);
 
             AssertFileComponentIds(2, rows);
+
+            var expectedModuleComponents = new[]
+            {
+                "ModuleComponents:FILE1.E535B765_1019_4A4F_B3EA_AE28870E6D73\tMergeModule.E535B765_1019_4A4F_B3EA_AE28870E6D73\t1033",
+                "ModuleComponents:FILE2.E535B765_1019_4A4F_B3EA_AE28870E6D73\tMergeModule.E535B765_1019_4A4F_B3EA_AE28870E6D73\t1033",
+            };
+
+            Assert.Equal(expectedModuleComponents, rows.Where(row => row.StartsWith("ModuleComponents:")));
         }
 
         [Fact]
@@ -215,7 +224,14 @@ namespace WixToolsetTest.CoreIntegration
                 {
                     result.AssertSuccess();
 
-                    return Query.QueryDatabase(msiPath, new[] { "Component", "File" })
+                    var tables = new List<string> { "Component", "File" };
+
+                    if (!isPackage)
+                    {
+                        tables.Add("ModuleComponents");
+                    }
+
+                    return Query.QueryDatabase(msiPath, tables.ToArray())
                         .OrderBy(s => s)
                         .ToArray();
                 }


### PR DESCRIPTION
Magic files (naked `File`s and `Files`) that are direct children of a `Module` need complex references from the generated component to that module, to ensure that they're wired up correctly as module components.

Fixes https://github.com/wixtoolset/issues/issues/8860