### PR TITLE
Fix loc and wix variables to allow dots in their identifier name again

### DIFF
--- a/src/wix/WixToolset.Core/Common.cs
+++ b/src/wix/WixToolset.Core/Common.cs
@@ -765,7 +765,8 @@ namespace WixToolset.Core
 
             var equalsDefaultValue = value.IndexOf('=', firstDot + 1, closeParen - firstDot);
             var end = equalsDefaultValue == -1 ? closeParen : equalsDefaultValue;
-            var secondDot = value.IndexOf('.', firstDot + 1, end - firstDot);
+            // bind variables may have a second dot to define their scope, other variables do not have scope and ignore additional dots.
+            var secondDot = ns == "bind" ? value.IndexOf('.', firstDot + 1, end - firstDot) : -1;
 
             if (secondDot == -1)
             {


### PR DESCRIPTION
Fixes wixtoolset/issues#8713

My solution ended up much closer to the original PR than I anticipated, closes #561