### PR TITLE
Audit all transitive dependencies and fix latest vulnerabilities

### DIFF
--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -32,7 +32,9 @@
     <ProjectUrl>https://wixtoolset.org/</ProjectUrl>
     <PackageIcon>wix.png</PackageIcon>
 
-    <GitVersionFile>version.txt</GitVersionFile>
+    <NuGetAudit>true</NuGetAudit>
+    <NuGetAuditMode>all</NuGetAuditMode>
+    <NuGetAuditLevel>low</NuGetAuditLevel>
   </PropertyGroup>
 
   <Import Project="Directory$(MSBuildProjectExtension).props" Condition=" Exists('Directory$(MSBuildProjectExtension).props') " />

--- a/src/api/burn/test/WixToolsetTest.BootstrapperApplicationApi/WixToolsetTest.BootstrapperApplicationApi.csproj
+++ b/src/api/burn/test/WixToolsetTest.BootstrapperApplicationApi/WixToolsetTest.BootstrapperApplicationApi.csproj
@@ -12,8 +12,4 @@
   <ItemGroup>
     <ProjectReference Include="..\..\WixToolset.BootstrapperApplicationApi\WixToolset.BootstrapperApplicationApi.csproj" />
   </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="WixInternal.TestSupport" />
-  </ItemGroup>
 </Project>

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -1,4 +1,13 @@
 <Project>
+  <PropertyGroup>
+    <CentralPackageTransitivePinningEnabled>true</CentralPackageTransitivePinningEnabled>
+  </PropertyGroup>
+
+  <!-- Pinned versions to address security vulnerabilities in transitive dependencies. Review as dependencies update. -->
+  <ItemGroup>
+    <PackageVersion Include="System.Private.Uri" Version="4.3.2" />
+  </ItemGroup>
+
   <ItemGroup>
     <PackageVersion Include="WixToolset.Dtf.Compression" Version="{packageversion}" />
     <PackageVersion Include="WixToolset.Dtf.Compression.Cab" Version="{packageversion}" />
@@ -43,35 +52,36 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.1" />
-    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="4.7.0" />
-    <PackageVersion Include="System.DirectoryServices" Version="4.7.0" />
-    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="4.7.0" />
-    <PackageVersion Include="System.Management" Version="4.7.0" />
+    <PackageVersion Include="System.Configuration.ConfigurationManager" Version="6.0.2" />
+    <PackageVersion Include="System.Diagnostics.PerformanceCounter" Version="6.0.2" />
+    <PackageVersion Include="System.DirectoryServices" Version="6.0.2" />
+    <PackageVersion Include="System.DirectoryServices.AccountManagement" Version="6.0.1" />
+    <PackageVersion Include="System.Management" Version="6.0.2" />
     <PackageVersion Include="System.IO.Compression" Version="4.3.0" />
-    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
+    <PackageVersion Include="System.IO.FileSystem.AccessControl" Version="5.0.0" />
     <PackageVersion Include="System.Net.NetworkInformation" Version="4.3.0" />
-    <PackageVersion Include="System.Reflection.Metadata" Version="1.8.1" />
-    <PackageVersion Include="System.Security.Principal.Windows" Version="4.7.0" />
-    <PackageVersion Include="System.Text.Encoding.CodePages" Version="4.7.1" />
-    <PackageVersion Include="System.Text.Json" Version="6.0.10" />
+    <PackageVersion Include="System.Reflection.Metadata" Version="6.0.2" />
+    <PackageVersion Include="System.Security.Principal.Windows" Version="5.0.0" />
+    <PackageVersion Include="System.Text.Encoding.CodePages" Version="6.0.1" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
+    <PackageVersion Include="System.Memory" Version="4.5.5" />
 
     <PackageVersion Include="Microsoft.AspNetCore.Owin" Version="3.1.13" />
     <PackageVersion Include="Microsoft.VisualStudio.Setup.Configuration.Native" Version="3.10.2154" />
-    <PackageVersion Include="Microsoft.Win32.Registry" Version="4.7.0" />
+    <PackageVersion Include="Microsoft.Win32.Registry" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="NuGet.Credentials" Version="6.10.1" />
-    <PackageVersion Include="NuGet.Protocol" Version="6.10.1" />
-    <PackageVersion Include="NuGet.Versioning" Version="6.10.1" />
+    <PackageVersion Include="NuGet.Credentials" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Protocol" Version="6.12.1" />
+    <PackageVersion Include="NuGet.Versioning" Version="6.12.1" />
   </ItemGroup>
 
   <!--
     These MSBuild versions are trapped in antiquity for heat.exe.
   -->
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework'">
-    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="14.3" />
+    <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="14.3.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFrameworkIdentifier)' != '.NETFramework'">
     <PackageVersion Include="Microsoft.Build.Tasks.Core" Version="15.7.179" />

--- a/src/internal/WixInternal.TestSupport/Builder.cs
+++ b/src/internal/WixInternal.TestSupport/Builder.cs
@@ -64,7 +64,7 @@ namespace WixInternal.TestSupport
                 foreach (var ext in this.ExtensionTypes)
                 {
                     args.Add("-ext");
-                    args.Add(Path.GetFullPath(new Uri(ext.Assembly.CodeBase).LocalPath));
+                    args.Add(Path.GetFullPath(ext.Assembly.Location));
                 }
 
                 args.AddRange(sourceFiles);
@@ -126,7 +126,7 @@ namespace WixInternal.TestSupport
                 foreach (var ext in this.ExtensionTypes)
                 {
                     firstBuildArgs.Add("-ext");
-                    firstBuildArgs.Add(Path.GetFullPath(new Uri(ext.Assembly.CodeBase).LocalPath));
+                    firstBuildArgs.Add(Path.GetFullPath(ext.Assembly.Location));
                 }
 
                 firstBuildArgs.AddRange(sourceFiles);
@@ -171,7 +171,7 @@ namespace WixInternal.TestSupport
                 foreach (var ext in this.ExtensionTypes)
                 {
                     decompileArgs.Add("-ext");
-                    decompileArgs.Add(Path.GetFullPath(new Uri(ext.Assembly.CodeBase).LocalPath));
+                    decompileArgs.Add(Path.GetFullPath(ext.Assembly.Location));
                 }
 
                 decompileFunc(decompileArgs.ToArray());
@@ -188,7 +188,7 @@ namespace WixInternal.TestSupport
                 foreach (var ext in this.ExtensionTypes)
                 {
                     secondBuildArgs.Add("-ext");
-                    secondBuildArgs.Add(Path.GetFullPath(new Uri(ext.Assembly.CodeBase).LocalPath));
+                    secondBuildArgs.Add(Path.GetFullPath(ext.Assembly.Location));
                 }
 
                 secondBuildArgs.Add("-bindpath");

--- a/src/internal/WixInternal.TestSupport/TestData.cs
+++ b/src/internal/WixInternal.TestSupport/TestData.cs
@@ -44,13 +44,13 @@ namespace WixInternal.TestSupport
 
         public static string Get(params string[] paths)
         {
-            var localPath = Path.GetDirectoryName(new Uri(Assembly.GetCallingAssembly().CodeBase).LocalPath);
+            var localPath = AppDomain.CurrentDomain.BaseDirectory;
             return Path.Combine(localPath, Path.Combine(paths));
         }
 
         public static string GetUnitTestLogsFolder([CallerFilePath] string path = "", [CallerMemberName] string method = "")
         {
-            var startingPath = Path.GetDirectoryName(new Uri(Assembly.GetCallingAssembly().CodeBase).LocalPath);
+            var startingPath = AppDomain.CurrentDomain.BaseDirectory;
             var buildPath = startingPath;
 
             while (!String.IsNullOrEmpty(buildPath))

--- a/src/internal/WixInternal.TestSupport/WixInternal.TestSupport.csproj
+++ b/src/internal/WixInternal.TestSupport/WixInternal.TestSupport.csproj
@@ -4,7 +4,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;net472</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <IsPackable>true</IsPackable>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>

--- a/src/test/burn/TestBA/TestBA.csproj
+++ b/src/test/burn/TestBA/TestBA.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>TestBA</AssemblyName>
     <RootNamespace>WixToolset.Test.BA</RootNamespace>

--- a/src/test/burn/TestBA/TestBA_x64.csproj
+++ b/src/test/burn/TestBA/TestBA_x64.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net462</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>TestBA</AssemblyName>
     <RootNamespace>WixToolset.Test.BA</RootNamespace>

--- a/src/test/burn/TestExe/TestExe.csproj
+++ b/src/test/burn/TestExe/TestExe.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net462;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <AssemblyName>TestExe</AssemblyName>
     <RootNamespace>TestExe</RootNamespace>
     <OutputType>Exe</OutputType>

--- a/src/test/burn/WixToolset.WixBA/WixToolset.WixBA.csproj
+++ b/src/test/burn/WixToolset.WixBA/WixToolset.WixBA.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>WixToolset.WixBA</AssemblyName>
     <RootNamespace>WixToolset.WixBA</RootNamespace>

--- a/src/test/burn/WixToolset.WixBA/WixToolset.WixBA_x64.csproj
+++ b/src/test/burn/WixToolset.WixBA/WixToolset.WixBA_x64.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0-windows</TargetFrameworks>
+    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>WixToolset.WixBA</AssemblyName>
     <RootNamespace>WixToolset.WixBA</RootNamespace>

--- a/src/test/wix/TestData/CsprojClassLibraryMultiTarget/CsprojClassLibraryMultiTarget.csproj
+++ b/src/test/wix/TestData/CsprojClassLibraryMultiTarget/CsprojClassLibraryMultiTarget.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net472;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/tools/heat/heat.csproj
+++ b/src/tools/heat/heat.csproj
@@ -39,5 +39,6 @@
     <PackageReference Include="System.Configuration.ConfigurationManager" />
     <PackageReference Include="System.Diagnostics.PerformanceCounter" />
     <PackageReference Include="System.DirectoryServices" />
+    <PackageReference Include="System.Memory" />
   </ItemGroup>
 </Project>

--- a/src/tools/test/WixToolsetTest.HeatTasks/WixToolsetTest.HeatTasks.csproj
+++ b/src/tools/test/WixToolsetTest.HeatTasks/WixToolsetTest.HeatTasks.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="WixInternal.TestSupport" /> 
-    <PackageReference Include="WixInternal.Core.TestPackage" /> 
+    <PackageReference Include="WixInternal.TestSupport" />
+    <PackageReference Include="WixInternal.Core.TestPackage" />
   </ItemGroup>
 </Project>

--- a/src/wix/WixInternal.Core.TestPackage/WixInternal.Core.TestPackage.csproj
+++ b/src/wix/WixInternal.Core.TestPackage/WixInternal.Core.TestPackage.csproj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <TargetFrameworks>net6.0;net472</TargetFrameworks>
     <Description>Internal WiX Toolset Test Package</Description>
     <DebugType>embedded</DebugType>
     <PublishRepositoryUrl>true</PublishRepositoryUrl>


### PR DESCRIPTION
Also, standardize .NET Core TFMs listed before .NET Framework TFMs for no reason but to be consistent