### PR TITLE
Use PerUserProgramFilesFolder for default INSTALLFOLDER in a per-user package

### DIFF
--- a/src/api/wix/WixToolset.Data/Symbols/WixPackageSymbol.cs
+++ b/src/api/wix/WixToolset.Data/Symbols/WixPackageSymbol.cs
@@ -18,6 +18,8 @@ namespace WixToolset.Data
                 new IntermediateFieldDefinition(nameof(WixPackageSymbolFields.Manufacturer), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(WixPackageSymbolFields.Attributes), IntermediateFieldType.Number),
                 new IntermediateFieldDefinition(nameof(WixPackageSymbolFields.Codepage), IntermediateFieldType.String),
+                new IntermediateFieldDefinition(nameof(WixPackageSymbolFields.Scope), IntermediateFieldType.Number),
+                new IntermediateFieldDefinition(nameof(WixPackageSymbolFields.UpgradeStrategy), IntermediateFieldType.Number),
             },
             typeof(WixPackageSymbol));
     }
@@ -37,19 +39,27 @@ namespace WixToolset.Data.Symbols
         Manufacturer,
         Attributes,
         Codepage,
+        Scope,
+        UpgradeStrategy,
     }
 
     [Flags]
     public enum WixPackageAttributes
     {
         None = 0x0,
-        PerMachine = 0x1,
+    }
+
+    public enum WixPackageScope
+    {
+        PerMachine,
+        PerUser,
+        PerUserOrMachine,
     }
 
     public enum WixPackageUpgradeStrategy
     {
-        None = 0x0,
-        MajorUpgrade = 0x1,
+        None,
+        MajorUpgrade,
     }
 
     public class WixPackageSymbol : IntermediateSymbol
@@ -112,12 +122,16 @@ namespace WixToolset.Data.Symbols
             set => this.Set((int)WixPackageSymbolFields.Codepage, value);
         }
 
-        public WixPackageUpgradeStrategy UpgradeStrategy
+        public WixPackageScope Scope
         {
-            get => (WixPackageUpgradeStrategy)this.Fields[(int)WixPackageSymbolFields.Attributes].AsNumber();
-            set => this.Set((int)WixPackageSymbolFields.Attributes, (int)value);
+            get => (WixPackageScope)this.Fields[(int)WixPackageSymbolFields.Scope].AsNumber();
+            set => this.Set((int)WixPackageSymbolFields.Scope, (int)value);
         }
 
-        public bool PerMachine => (this.Attributes & WixPackageAttributes.PerMachine) == WixPackageAttributes.PerMachine;
+        public WixPackageUpgradeStrategy UpgradeStrategy
+        {
+            get => (WixPackageUpgradeStrategy)this.Fields[(int)WixPackageSymbolFields.UpgradeStrategy].AsNumber();
+            set => this.Set((int)WixPackageSymbolFields.UpgradeStrategy, (int)value);
+        }
     }
 }

--- a/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerStandard.cs
+++ b/src/api/wix/WixToolset.Data/WindowsInstaller/WindowsInstallerStandard.cs
@@ -223,6 +223,7 @@ namespace WixToolset.Data.WindowsInstaller
             ["MyPicturesFolder"] = "Pictures",
             ["NetHoodFolder"] = "NetHood",
             ["PersonalFolder"] = "Personal",
+            ["PerUserProgramFilesFolder"] = "Programs",
             ["PrintHoodFolder"] = "Printers",
             ["ProgramFilesFolder"] = "PFiles",
             ["ProgramFiles64Folder"] = "PFiles64",
@@ -264,7 +265,7 @@ namespace WixToolset.Data.WindowsInstaller
                 new WixActionSymbol(null, new Identifier(AccessModifier.Virtual, "AdminUISequence/FileCost"))         { Action="FileCost",         Sequence=900, SequenceTable=SequenceTable.AdminUISequence },
                 new WixActionSymbol(null, new Identifier(AccessModifier.Virtual, "AdminUISequence/CostFinalize"))     { Action="CostFinalize",     Sequence=1000, SequenceTable=SequenceTable.AdminUISequence },
                 new WixActionSymbol(null, new Identifier(AccessModifier.Virtual, "AdminUISequence/ExecuteAction"))    { Action="ExecuteAction",    Sequence=1300, SequenceTable=SequenceTable.AdminUISequence },
-                
+
                 // AdvertiseExecuteSequence
                 new WixActionSymbol(null, new Identifier(AccessModifier.Virtual, "AdvertiseExecuteSequence/CostInitialize"))        { Action="CostInitialize",        Sequence=800, SequenceTable=SequenceTable.AdvertiseExecuteSequence },
                 new WixActionSymbol(null, new Identifier(AccessModifier.Virtual, "AdvertiseExecuteSequence/CostFinalize"))          { Action="CostFinalize",          Sequence=1000, SequenceTable=SequenceTable.AdvertiseExecuteSequence },

--- a/src/api/wix/WixToolset.Data/WixStandardLibrary.cs
+++ b/src/api/wix/WixToolset.Data/WixStandardLibrary.cs
@@ -162,6 +162,9 @@ namespace WixToolset.Data
                 case "CommonFiles6432Folder":
                     return platform == Platform.X86 ? "CommonFilesFolder" : "CommonFiles64Folder";
 
+                case "PerUserProgramFilesFolder":
+                    return "LocalAppDataFolder";
+
                 case "ProgramFiles6432Folder":
                     return platform == Platform.X86 ? "ProgramFilesFolder" : "ProgramFiles64Folder";
 

--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -30,8 +30,7 @@ namespace WixToolset.Core
             string codepage = null;
             var productCode = "*";
             string productLanguage = null;
-            var isPerMachine = true;
-            var isPerUserOrMachine = false;
+            var scope = WixPackageScope.PerMachine;
             string upgradeCode = null;
             string manufacturer = null;
             string version = null;
@@ -91,12 +90,11 @@ namespace WixToolset.Core
                                 // handled below after we create the section.
                                 break;
                             case "perUser":
-                                isPerMachine = false;
+                                scope = WixPackageScope.PerUser;
                                 sourceBits |= 8;
                                 break;
                             case "perUserOrMachine":
-                                isPerMachine = false;
-                                isPerUserOrMachine = true;
+                                scope = WixPackageScope.PerUserOrMachine;
                                 break;
                             default:
                                 this.Core.Write(ErrorMessages.IllegalAttributeValue(sourceLineNumbers, node.Name.LocalName, attrib.Name.LocalName, installScope, "perMachine", "perUser", "perUserOrMachine"));
@@ -191,12 +189,12 @@ namespace WixToolset.Core
                     this.AddProperty(sourceLineNumbers, new Identifier(AccessModifier.Global, "UpgradeCode"), upgradeCode, false, false, false, true);
                 }
 
-                if (isPerUserOrMachine)
+                if (scope == WixPackageScope.PerUserOrMachine)
                 {
                     this.AddProperty(sourceLineNumbers, new Identifier(AccessModifier.Global, "ALLUSERS"), "2", false, false, false, false);
                     this.AddProperty(sourceLineNumbers, new Identifier(AccessModifier.Global, "MSIINSTALLPERUSER"), "1", false, false, false, false);
                 }
-                else if (isPerMachine)
+                else if (scope == WixPackageScope.PerMachine)
                 {
                     this.AddProperty(sourceLineNumbers, new Identifier(AccessModifier.Global, "ALLUSERS"), "1", false, false, false, false);
                 }
@@ -402,8 +400,8 @@ namespace WixToolset.Core
                         Language = productLanguage,
                         Version = version,
                         Manufacturer = manufacturer,
-                        Attributes = isPerMachine ? WixPackageAttributes.PerMachine : WixPackageAttributes.None,
                         Codepage = codepage,
+                        Scope = scope,
                         UpgradeStrategy = upgradeStrategy,
                     });
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AllUsers/PerMachine.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AllUsers/PerMachine.wxs
@@ -7,7 +7,7 @@
     <MajorUpgrade DowngradeErrorMessage="Downgrade not allowed" />
 
     <Feature Id="ProductFeature" Title="Feature title">
-        <Component Directory="DesktopFolder">
+        <Component>
             <File Source="PerUser.wxs" />
         </Component>
     </Feature>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AllUsers/PerUser.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AllUsers/PerUser.wxs
@@ -7,7 +7,7 @@
     <MajorUpgrade DowngradeErrorMessage="Downgrade not allowed" />
 
     <Feature Id="ProductFeature" Title="Feature title">
-        <Component Directory="DesktopFolder">
+        <Component>
             <File Source="PerUser.wxs" />
         </Component>
     </Feature>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AllUsers/PerUserOrMachine.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/AllUsers/PerUserOrMachine.wxs
@@ -7,7 +7,7 @@
     <MajorUpgrade DowngradeErrorMessage="Downgrade not allowed" />
 
     <Feature Id="ProductFeature" Title="Feature title">
-        <Component Directory="DesktopFolder">
+        <Component>
             <File Source="PerUser.wxs" />
         </Component>
     </Feature>


### PR DESCRIPTION
Also, adds a standard directory for `PerUserProgramFilesFolder`. 

Fixes wixtoolset/issues#8101