### PR TITLE
Overridable WixVariables should be treated as virtual

### DIFF
--- a/src/wix/WixToolset.Core/Compiler_Package.cs
+++ b/src/wix/WixToolset.Core/Compiler_Package.cs
@@ -5033,6 +5033,11 @@ namespace WixToolset.Core
 
             if (!this.Core.EncounteredError)
             {
+                if (overridable)
+                {
+                    id = new Identifier(AccessModifier.Virtual, id.Id);
+                }
+
                 this.Core.AddSymbol(new WixVariableSymbol(sourceLineNumbers, id)
                 {
                     Value = value,

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WixVariable/PackageWithOverriddenBindVariable.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WixVariable/PackageWithOverriddenBindVariable.wxs
@@ -1,0 +1,13 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Version="1.0.0" Name="MsiPackage" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
+    <PropertyRef Id="Test" />
+
+    <WixVariable Id="override TestWixVariable" Value="0"/>
+  </Package>
+
+  <Fragment>
+    <Property Id="Test" Value="!(wix.TestWixVariable)" />
+
+    <WixVariable Id="TestWixVariable" Value="1" Overridable="true"/>
+  </Fragment>
+</Wix>


### PR DESCRIPTION
Fixes wixtoolset/issues#8528