### PR TITLE
Fix Firewall E2E Test under Windows Sandbox (with Windows Insider release)

### DIFF
--- a/src/test/burn/WixTestTools/Firewall/UniqueCheck.cs
+++ b/src/test/burn/WixTestTools/Firewall/UniqueCheck.cs
@@ -23,6 +23,7 @@ namespace WixTestTools.Firewall
             this.ApplicationName = details.ApplicationName;
             this.LocalUserOwner = details.LocalUserOwner;
             this.RemoteAddresses = details.RemoteAddresses;
+            this.Grouping = details.Grouping;
         }
 
 
@@ -39,6 +40,8 @@ namespace WixTestTools.Firewall
         public string LocalUserOwner { get; set; }
 
         public string RemoteAddresses { get; set; }
+
+        public string Grouping { get; set; }
 
         public bool FirewallRuleIsUnique(INetFwRule3 rule)
         {
@@ -73,6 +76,11 @@ namespace WixTestTools.Firewall
             }
 
             if (this.RemoteAddresses != null && rule.RemoteAddresses != this.RemoteAddresses)
+            {
+                return false;
+            }
+
+            if (this.Grouping != null && rule.Grouping != this.Grouping)
             {
                 return false;
             }


### PR DESCRIPTION
I suspect a recent update to the Windows Insider build has resulted in my Windows Sandbox producing the below MSI E2E test failures.

```
Failed WixToolsetTest.MsiE2E.FirewallExtensionTests.VerifierSelfTest [93 ms]
Error Message:
Assert Failure: Groupings differ on rule: Windows Feature Experience Pack
Expected: @{MicrosoftWindows.LKG.SpeechRuntime_1000.27764.1000.0_x64__cw5n1h2txyewy?ms-resource://MicrosoftWindows.LKG.SpeechRuntime/resources/ProductPkgDisplayName}
Actual: @{MicrosoftWindows.LKG.TwinSxS_1000.27764.1000.0_x64__cw5n1h2txyewy?ms-resource://MicrosoftWindows.LKG.TwinSxS/resources/ProductPkgDisplayName}

Direction: NET_FW_RULE_DIR_OUT
Profile: 7
Protocol: 256
ApplicationName:
LocalUserOwner: S-1-5-18
...
```
![image](https://github.com/user-attachments/assets/14e9baf3-b3fc-43c6-afdc-b8c56ea95154)




This is potentially a Windows OS bug (it was from a Windows Insider build), however it does show that it's possible in the Firewall API to have multiple rules which differ only in their Grouping.
So the testbench should consider different Grouping as making for a unique firewall rule.