### PR TITLE
Support WiX3-compantible auto-guids for registry key path

### DIFF
--- a/src/api/wix/WixToolset.Data/Symbols/ComponentSymbol.cs
+++ b/src/api/wix/WixToolset.Data/Symbols/ComponentSymbol.cs
@@ -24,6 +24,7 @@ namespace WixToolset.Data
                 new IntermediateFieldDefinition(nameof(ComponentSymbolFields.Condition), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(ComponentSymbolFields.KeyPath), IntermediateFieldType.String),
                 new IntermediateFieldDefinition(nameof(ComponentSymbolFields.KeyPathType), IntermediateFieldType.Number),
+                new IntermediateFieldDefinition(nameof(ComponentSymbolFields.WiX3CompatibleGuid), IntermediateFieldType.Bool),
             },
             typeof(ComponentSymbol));
     }
@@ -47,6 +48,7 @@ namespace WixToolset.Data.Symbols
         Condition,
         KeyPath,
         KeyPathType,
+        WiX3CompatibleGuid,
     }
 
     public enum ComponentLocation
@@ -150,6 +152,12 @@ namespace WixToolset.Data.Symbols
         {
             get => (ComponentKeyPathType)this.Fields[(int)ComponentSymbolFields.KeyPathType].AsNumber();
             set => this.Set((int)ComponentSymbolFields.KeyPathType, (int)value);
+        }
+
+        public bool WiX3CompatibleGuid
+        {
+            get => this.Fields[(int)ComponentSymbolFields.WiX3CompatibleGuid].AsBool();
+            set => this.Set((int)ComponentSymbolFields.WiX3CompatibleGuid, value);
         }
     }
 }

--- a/src/api/wix/WixToolset.Data/WarningMessages.cs
+++ b/src/api/wix/WixToolset.Data/WarningMessages.cs
@@ -719,6 +719,11 @@ namespace WixToolset.Data
             return Message(sourceLineNumbers, Ids.VBScriptIsDeprecated, "VBScript is a deprecated Windows component: https://learn.microsoft.com/en-us/windows/whats-new/deprecated-features. VBScript custom actions might fail on some Windows systems. Rewrite or eliminate VBScript custom actions for best compatibility.");
         }
 
+        public static Message AlreadyWiX3CompatibleGuid(SourceLineNumber sourceLineNumbers, ComponentKeyPathType keyPathType)
+        {
+            return Message(sourceLineNumbers, Ids.AlreadyWiX3CompatibleGuid, "Components with KeyPath type {0} have WiX3-compatible GUID by default. Attribute WiX3CompatibleGuid is redundant.", keyPathType);
+        }
+
         private static Message Message(SourceLineNumber sourceLineNumber, Ids id, string format, params object[] args)
         {
             return new Message(sourceLineNumber, MessageLevel.Warning, (int)id, format, args);
@@ -861,6 +866,7 @@ namespace WixToolset.Data
             ExePackageDetectInformationRecommended = 1161,
             InvalidWixVersion = 1162,
             VBScriptIsDeprecated = 1163,
+            AlreadyWiX3CompatibleGuid = 1164,
         }
     }
 }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/FinalizeComponentGuids.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/FinalizeComponentGuids.cs
@@ -99,6 +99,10 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 {
                     var bitness = componentSymbol.Win64 ? "64" : String.Empty;
                     var regkey = String.Concat(bitness, registrySymbol.Root, "\\", registrySymbol.Key, "\\", registrySymbol.Name);
+                    if (componentSymbol.WiX3CompatibleGuid)
+                    {
+                        regkey = String.Concat(bitness, (int)registrySymbol.Root, "\\", registrySymbol.Key, "\\", registrySymbol.Name);
+                    }
                     componentSymbol.ComponentId = this.BackendHelper.CreateGuid(BindDatabaseCommand.WixComponentGuidNamespace, regkey.ToLowerInvariant());
                 }
             }

--- a/src/wix/WixToolset.Core/Compiler.cs
+++ b/src/wix/WixToolset.Core/Compiler.cs
@@ -2125,6 +2125,7 @@ namespace WixToolset.Core
             var location = ComponentLocation.LocalOnly;
             var disableRegistryReflection = false;
 
+            var wiX3CompatibleGuid = false;
             var neverOverwrite = false;
             var permanent = false;
             var shared = false;
@@ -2188,6 +2189,9 @@ namespace WixToolset.Core
                         break;
                     case "Guid":
                         guid = this.Core.GetAttributeGuidValue(sourceLineNumbers, attrib, true, true);
+                        break;
+                    case "WiX3CompatibleGuid":
+                        wiX3CompatibleGuid = YesNoType.Yes == this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib);
                         break;
                     case "KeyPath":
                         if (YesNoType.Yes == this.Core.GetAttributeYesNoValue(sourceLineNumbers, attrib))
@@ -2523,6 +2527,15 @@ namespace WixToolset.Core
                 }
             }
 
+            if (wiX3CompatibleGuid && (guid != "*"))
+            {
+                this.Core.Write(ErrorMessages.IllegalAttributeValueWithoutOtherAttribute(sourceLineNumbers, node.Name.LocalName, "WiX3CompatibleGuid", "yes", "Guid", "*"));
+            }
+            if (wiX3CompatibleGuid && (ComponentKeyPathType.Registry != keyPathType))
+            {
+                this.Core.Write(WarningMessages.AlreadyWiX3CompatibleGuid(sourceLineNumbers, keyPathType));
+            }
+
             // finally add the Component table row
             if (!this.Core.EncounteredError)
             {
@@ -2542,6 +2555,7 @@ namespace WixToolset.Core
                     Transitive = transitive,
                     UninstallWhenSuperseded = uninstallWhenSuperseded,
                     Win64 = win64,
+                    WiX3CompatibleGuid = wiX3CompatibleGuid,
                 });
 
                 if (multiInstance)

--- a/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/MsiQueryFixture.cs
@@ -2,6 +2,7 @@
 
 namespace WixToolsetTest.CoreIntegration
 {
+    using System;
     using System.IO;
     using System.Linq;
     using WixInternal.Core.TestPackage;
@@ -211,6 +212,71 @@ namespace WixToolsetTest.CoreIntegration
                     "AppSearch:SAMPLEREGFOUND\tSampleRegSearch",
                     "RegLocator:SampleRegSearch\t2\tSampleReg\t\t18",
                 }, results);
+            }
+        }
+
+        [Fact]
+        public void WiX3CompatibleGuid()
+        {
+            var folder = TestData.Get(@"TestData\WiX3CompatibleGuid");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Package.wxs"),
+                    Path.Combine(folder, "WiX3CompatibleGuid.wxs"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                result.AssertSuccess();
+
+                Assert.True(File.Exists(msiPath));
+                var results = Query.QueryDatabase(msiPath, new[] { "Component" });
+
+                Assert.Equal(2, results.Length);
+                Assert.Contains(results, component => component.Contains("WiX3CompatibleGuid") && component.Contains("8BAF5399-2FD2-50B6-ABDA-98FB3A5BB148", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(results, component => component.Contains("WiX4CompatibleGuid") && !component.Contains("8BAF5399-2FD2-50B6-ABDA-98FB3A5BB148", StringComparison.InvariantCultureIgnoreCase));
+            }
+        }
+
+        [Fact]
+        public void WiX4CompatibleGuid()
+        {
+            var folder = TestData.Get(@"TestData\WiX4CompatibleGuid");
+
+            using (var fs = new DisposableFileSystem())
+            {
+                var baseFolder = fs.GetFolder();
+                var intermediateFolder = Path.Combine(baseFolder, "obj");
+                var msiPath = Path.Combine(baseFolder, @"bin\test.msi");
+
+                var result = WixRunner.Execute(new[]
+                {
+                    "build",
+                    Path.Combine(folder, "Package.wxs"),
+                    Path.Combine(folder, "WiX4CompatibleGuid.wxs"),
+                    "-intermediateFolder", intermediateFolder,
+                    "-o", msiPath
+                });
+
+                result.AssertSuccess();
+
+                Assert.True(File.Exists(msiPath));
+                var results = Query.QueryDatabase(msiPath, new[] { "Component" });
+
+                Assert.Equal(5, results.Length);
+                Assert.Contains(results, component => component.Contains("hklm") && component.Contains("8A4C3648-26AF-5E7E-B64B-D97961856FA4", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(results, component => component.Contains("hkcr") && component.Contains("B40FBCDB-D01C-575F-9030-7B95813A419C", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(results, component => component.Contains("hkcu") && component.Contains("04EB5AB4-FFF7-53D5-A913-1C146FC61EF2", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(results, component => component.Contains("hku") && component.Contains("CC64CDBB-077E-532B-9F95-A1E1EB162875", StringComparison.InvariantCultureIgnoreCase));
+                Assert.Contains(results, component => component.Contains("file") && component.Contains("C207E21E-B6F4-537A-A8AB-620DD88646D6", StringComparison.InvariantCultureIgnoreCase));
             }
         }
 

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WiX3CompatibleGuid/Package.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WiX3CompatibleGuid/Package.wxs
@@ -1,0 +1,16 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="WiX3CompatibleGuid" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
+
+    <MajorUpgrade DowngradeErrorMessage="Dont care" />
+
+    <Feature Id="ProductFeature" Title="Title">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="WiX3CompatibleGuid" />
+    </StandardDirectory>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WiX3CompatibleGuid/WiX3CompatibleGuid.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WiX3CompatibleGuid/WiX3CompatibleGuid.wxs
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents" Directory="TARGETDIR">
+            <!-- Expecting {8BAF5399-2FD2-50B6-ABDA-98FB3A5BB148} -->
+            <Component Id="WiX3CompatibleGuid" WiX3CompatibleGuid="yes" Bitness="always32" Condition="x=y">
+                <RegistryValue Root="HKLM" Key="SOFTWARE\WiX3CompatiblityCheck" Name="Test" Value="test value" />
+            </Component>
+
+            <!-- Expecting *not* {8BAF5399-2FD2-50B6-ABDA-98FB3A5BB148} -->
+            <Component Id="WiX4CompatibleGuid" Bitness="always32" Condition="x=z">
+                <RegistryValue Root="HKLM" Key="SOFTWARE\WiX3CompatiblityCheck" Name="Test" Value="test value" />
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WiX4CompatibleGuid/Package.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WiX4CompatibleGuid/Package.wxs
@@ -1,0 +1,16 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Name="WiX3CompatibleGuid" Codepage="1252" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a" Compressed="no" InstallerVersion="200" Scope="perMachine">
+
+    <MajorUpgrade DowngradeErrorMessage="Dont care" />
+
+    <Feature Id="ProductFeature" Title="Title">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="WiX4CompatibleGuid" />
+    </StandardDirectory>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WiX4CompatibleGuid/WiX4CompatibleGuid.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/WiX4CompatibleGuid/WiX4CompatibleGuid.wxs
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Fragment>
+        <ComponentGroup Id="ProductComponents" Directory="TARGETDIR">
+
+            <!-- Expecting {8A4C3648-26AF-5E7E-B64B-D97961856FA4} -->
+            <Component Directory='TARGETDIR' Bitness="always32" Id="hklm">
+                <RegistryValue Root="HKLM" Key="SOFTWARE\WiX3CompatiblityCheck" Name="Test" Value="test value" Type="string"/>
+            </Component>
+
+            <!-- Expecting {B40FBCDB-D01C-575F-9030-7B95813A419C} -->
+            <Component Directory='TARGETDIR' Bitness="always32" Id="hkcr">
+                <RegistryValue Root="HKCR" Key="SOFTWARE\WiX3CompatiblityCheck" Name="Test" Value="test value" Type="string"/>
+            </Component>
+
+            <!-- Expecting {04EB5AB4-FFF7-53D5-A913-1C146FC61EF2} -->
+            <Component Directory='TARGETDIR' Bitness="always32" Id="hkcu">
+                <RegistryValue Root="HKCU" Key="SOFTWARE\WiX3CompatiblityCheck" Name="Test" Value="test value" Type="string"/>
+            </Component>
+
+            <!-- Expecting {CC64CDBB-077E-532B-9F95-A1E1EB162875} -->
+            <Component Directory='TARGETDIR' Bitness="always32" Id="hku">
+                <RegistryValue Root="HKU" Key="SOFTWARE\WiX3CompatiblityCheck" Name="Test" Value="test value" Type="string"/>
+            </Component>
+
+            <!-- Expecting {C207E21E-B6F4-537A-A8AB-620DD88646D6} -->
+            <Component Directory='INSTALLFOLDER' Bitness="always32" Id="file">
+                <File Source='$(sys.SOURCEFILEPATH)' Name='test.wxs'/>
+            </Component>
+        </ComponentGroup>
+    </Fragment>
+</Wix>


### PR DESCRIPTION
Fix [#8896](https://github.com/wixtoolset/issues/issues/8896)
By default, generated GUID will be compatible with WiX4+
Added an attribute to generate WiX3-compatible GUID: `Component/@WiX3CompatibleGuid=yes/no`
