### PR TITLE
Raise conversion warning for After and Before attributes

### DIFF
--- a/src/wix/WixToolset.Converters/WixConverter.cs
+++ b/src/wix/WixToolset.Converters/WixConverter.cs
@@ -211,7 +211,7 @@ namespace WixToolset.Converters
             { "WixSchedHttpUrlReservationsInstall", "Wix4SchedHttpUrlReservationsInstall_<PlatformSuffix>" },
             { "ConfigureIIs", "Wix4ConfigureIIs_<PlatformSuffix>" },
             { "UninstallCertificates", "Wix4UninstallCertificates_<PlatformSuffix>" },
-            { "InstallCertificates", "Wix4_<PlatformSuffix>" },
+            { "InstallCertificates", "Wix4InstallCertificates_<PlatformSuffix>" },
             { "MessageQueuingUninstall", "Wix4MessageQueuingUninstall_<PlatformSuffix>" },
             { "MessageQueuingInstall", "Wix4_MessageQueuingInstall<PlatformSuffix>" },
             { "NetFxScheduleNativeImage", "Wix4NetFxScheduleNativeImage_<PlatformSuffix>" },
@@ -914,13 +914,18 @@ namespace WixToolset.Converters
 
         private void ConvertCustomElement(XElement element)
         {
-            var actionId = element.Attribute("Action")?.Value;
+            var attributes = new string[] { "Action", "After", "Before" };
 
-            if (actionId != null
-                && CustomActionIdsWithPlatformSuffix.TryGetValue(actionId, out var replacementId))
+            foreach (var attribute in attributes)
             {
-                this.OnError(ConverterTestType.CustomActionIdsIncludePlatformSuffix, element,
-                    $"Custom action ids have changed in WiX v4 extensions to support platform-specific custom actions. The platform is applied as a suffix: _X86, _X64, _A64 (Arm64). When manually rescheduling custom action '{actionId}', you must use the new custom action id '{replacementId}'. See the conversion FAQ for more information: https://wixtoolset.org/docs/fourthree/faqs/#converting-packages");
+                var attributeValue = element.Attribute(attribute)?.Value;
+
+                if (attributeValue != null
+                    && CustomActionIdsWithPlatformSuffix.TryGetValue(attributeValue, out var replacementId))
+                {
+                    this.OnError(ConverterTestType.CustomActionIdsIncludePlatformSuffix, element,
+                        $"Custom action ids have changed in WiX v4 extensions to support platform-specific custom actions. The platform is applied as a suffix: _X86, _X64, _A64 (Arm64). When manually rescheduling custom action '{attributeValue}', you must use the new custom action id '{replacementId}'. See the conversion FAQ for more information: https://wixtoolset.org/docs/fourthree/faqs/#converting-packages");
+                }
             }
         }
 
@@ -1830,6 +1835,7 @@ namespace WixToolset.Converters
         {
             foreach (var child in element.Elements())
             {
+                this.ConvertCustomActionElement(child);
                 this.ConvertInnerTextToAttribute(child, "Condition");
             }
         }
@@ -1846,6 +1852,7 @@ namespace WixToolset.Converters
 
         private void ConvertSetPropertyElement(XElement element)
         {
+            this.ConvertCustomElement(element);
             this.ConvertInnerTextToAttribute(element, "Condition");
         }
 

--- a/src/wix/test/WixToolsetTest.Converters/SequenceFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/SequenceFixture.cs
@@ -45,5 +45,40 @@ namespace WixToolsetTest.Converters
             var actualLines = UnformattedDocumentLines(document);
             WixAssert.CompareLineByLine(expected, actualLines);
         }
+
+        [Fact]
+        public void FixConditionWixCa()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <InstallUISequence>",
+                "      <Custom Action='ExampleCA' After='WixQueryOsDirs'>NOT Installed</Custom>",
+                "    </InstallUISequence>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <InstallUISequence>",
+                "      <Custom Action=\"ExampleCA\" After=\"WixQueryOsDirs\" Condition=\"NOT Installed\" />",
+                "    </InstallUISequence>",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(3, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
     }
 }

--- a/src/wix/test/WixToolsetTest.Converters/SetPropertyFixture.cs
+++ b/src/wix/test/WixToolsetTest.Converters/SetPropertyFixture.cs
@@ -1,0 +1,47 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.Converters
+{
+    using System;
+    using System.Xml.Linq;
+    using WixInternal.TestSupport;
+    using WixToolset.Converters;
+    using WixToolsetTest.Converters.Mocks;
+    using Xunit;
+
+    public class SetPropertyFixture : BaseConverterFixture
+    {
+        [Fact]
+        public void FixConditionWixCa()
+        {
+            var parse = String.Join(Environment.NewLine,
+                "<Wix xmlns='http://schemas.microsoft.com/wix/2006/wi'>",
+                "  <Fragment>",
+                "    <SetProperty Id='INSTALLFOLDER' ",
+                "      After='WixQueryOsDirs'" +
+                "      Value='test'>NOT Installed</SetProperty>",
+                "  </Fragment>",
+                "</Wix>");
+
+            var expected = new[]
+            {
+                "<Wix xmlns=\"http://wixtoolset.org/schemas/v4/wxs\">",
+                "  <Fragment>",
+                "    <SetProperty Id=\"INSTALLFOLDER\" After=\"WixQueryOsDirs\" Value=\"test\" Condition=\"NOT Installed\" />",
+                "  </Fragment>",
+                "</Wix>"
+            };
+
+            var document = XDocument.Parse(parse, LoadOptions.PreserveWhitespace | LoadOptions.SetLineInfo);
+
+            var messaging = new MockMessaging();
+            var converter = new WixConverter(messaging, 2, null, null);
+
+            var errors = converter.ConvertDocument(document);
+            Assert.Equal(3, errors);
+
+            var actualLines = UnformattedDocumentLines(document);
+            WixAssert.CompareLineByLine(expected, actualLines);
+        }
+    }
+}


### PR DESCRIPTION
Raise conversion warning for After and Before attributes, at least on Sequence and SetProperty elements