### PR TITLE
Fix up missing 'Wix4' prefixes on MSMQ Permission tables.

### DIFF
--- a/src/ext/Msmq/ca/mqqueuesched.cpp
+++ b/src/ext/Msmq/ca/mqqueuesched.cpp
@@ -10,9 +10,9 @@ LPCWSTR vcsMessageQueueQuery =
 enum eMessageQueueQuery { mqqMessageQueue = 1, mqqComponent,  mqqBasePriority, mqqJournalQuota, mqqLabel, mqqMulticastAddress, mqqPathName, mqqPrivLevel, mqqQuota, mqqServiceTypeGuid, mqqAttributes };
 
 LPCWSTR vcsMessageQueueUserPermissionQuery =
-    L"SELECT `MessageQueueUserPermission`, `MessageQueue_`, `MessageQueueUserPermission`.`Component_`, `Domain`, `Name`, `Permissions` FROM `Wix4MessageQueueUserPermission`, `Wix4User` WHERE `User_` = `User`";
+    L"SELECT `MessageQueueUserPermission`, `MessageQueue_`, `Wix4MessageQueueUserPermission`.`Component_`, `Domain`, `Name`, `Permissions` FROM `Wix4MessageQueueUserPermission`, `Wix4User` WHERE `User_` = `User`";
 LPCWSTR vcsMessageQueueGroupPermissionQuery =
-    L"SELECT `MessageQueueGroupPermission`, `MessageQueue_`, `MessageQueueGroupPermission`.`Component_`, `Domain`, `Name`, `Permissions` FROM `Wix4MessageQueueGroupPermission`, `Wix4Group` WHERE `Group_` = `Group`";
+    L"SELECT `MessageQueueGroupPermission`, `MessageQueue_`, `Wix4MessageQueueGroupPermission`.`Component_`, `Domain`, `Name`, `Permissions` FROM `Wix4MessageQueueGroupPermission`, `Wix4Group` WHERE `Group_` = `Group`";
 enum eMessageQueuePermissionQuery { mqpqMessageQueuePermission = 1, mqpqMessageQueue, mqpqComponent, mqpqDomain, mqpqName, mqpqPermissions };
 
 
@@ -94,7 +94,7 @@ HRESULT MqiMessageQueueRead(
 
     // loop through all partitions
     hr = WcaOpenExecuteView(vcsMessageQueueQuery, &hView);
-    ExitOnFailure(hr, "Failed to execute view on MessageQueue table");
+    ExitOnFailure(hr, "Failed to execute view on Wix4MessageQueue table");
 
     while (S_OK == (hr = WcaFetchRecord(hView, &hRec)))
     {
@@ -324,14 +324,14 @@ HRESULT MqiMessageQueuePermissionRead(
     HRESULT hr = S_OK;
 
     // read message queue user permissions
-    if (S_OK == WcaTableExists(L"MessageQueueUserPermission"))
+    if (S_OK == WcaTableExists(L"Wix4MessageQueueUserPermission"))
     {
         hr = MessageQueueTrusteePermissionsRead(vcsMessageQueueUserPermissionQuery, pMessageQueueList, pList);
         ExitOnFailure(hr, "Failed to read message queue user permissions");
     }
 
     // read message queue group permissions
-    if (S_OK == WcaTableExists(L"MessageQueueGroupPermission"))
+    if (S_OK == WcaTableExists(L"Wix4MessageQueueGroupPermission"))
     {
         hr = MessageQueueTrusteePermissionsRead(vcsMessageQueueGroupPermissionQuery, pMessageQueueList, pList);
         ExitOnFailure(hr, "Failed to read message queue group permissions");

--- a/src/ext/Msmq/ca/mqsched.cpp
+++ b/src/ext/Msmq/ca/mqsched.cpp
@@ -49,7 +49,7 @@ extern "C" UINT __stdcall MessageQueuingInstall(MSIHANDLE hInstall)
 
     // read message queues
     hr = MqiMessageQueueRead(&lstMessageQueues);
-    ExitOnFailure(hr, "Failed to read MessageQueue table");
+    ExitOnFailure(hr, "Failed to read Wix4MessageQueue table");
 
     // read message queue permissions
     hr = MqiMessageQueuePermissionRead(&lstMessageQueues, &lstMessageQueuePermissions);
@@ -78,7 +78,7 @@ extern "C" UINT __stdcall MessageQueuingInstall(MSIHANDLE hInstall)
 
         hr = MqiMessageQueuePermissionInstall(&lstMessageQueuePermissions, &pwzExecuteActionData);
         ExitOnFailure(hr, "Failed to add message queue permissions to execute action data");
-        iCost += lstMessageQueues.iInstallCount * COST_MESSAGE_QUEUE_PERMISSION_ADD;
+        iCost += lstMessageQueuePermissions.iInstallCount * COST_MESSAGE_QUEUE_PERMISSION_ADD;
 
         hr = WcaDoDeferredAction(CUSTOM_ACTION_DECORATION(L"MessageQueuingExecuteInstall"), pwzExecuteActionData, iCost);
         ExitOnFailure(hr, "Failed to schedule MessageQueuingExecuteInstall");
@@ -148,7 +148,7 @@ extern "C" UINT __stdcall MessageQueuingUninstall(MSIHANDLE hInstall)
 
     // read message queues
     hr = MqiMessageQueueRead(&lstMessageQueues);
-    ExitOnFailure(hr, "Failed to read MessageQueue table");
+    ExitOnFailure(hr, "Failed to read Wix4MessageQueue table");
 
     // read message queue permissions
     hr = MqiMessageQueuePermissionRead(&lstMessageQueues, &lstMessageQueuePermissions);

--- a/src/ext/Msmq/test/WixToolsetTest.Msmq/MsmqExtensionFixture.cs
+++ b/src/ext/Msmq/test/WixToolsetTest.Msmq/MsmqExtensionFixture.cs
@@ -6,6 +6,7 @@ namespace WixToolsetTest.Msmq
     using WixInternal.TestSupport;
     using WixInternal.Core.TestPackage;
     using WixToolset.Msmq;
+    using WixToolset.Util;
     using Xunit;
 
     public class MsmqExtensionFixture
@@ -14,9 +15,9 @@ namespace WixToolsetTest.Msmq
         public void CanBuildUsingMessageQueue()
         {
             var folder = TestData.Get(@"TestData\UsingMessageQueue");
-            var build = new Builder(folder, typeof(MsmqExtensionFactory), new[] { folder });
+            var build = new Builder(folder, new[] { typeof(MsmqExtensionFactory), typeof(UtilExtensionFactory) }, new[] { folder });
 
-            var results = build.BuildAndQuery(Build, "Wix4MessageQueue", "CustomAction");
+            var results = build.BuildAndQuery(Build, "Wix4MessageQueue", "CustomAction", "Wix4MessageQueueUserPermission", "Wix4MessageQueueGroupPermission", "Wix4Group", "Wix4User");
             WixAssert.CompareLineByLine(new[]
             {
                 "CustomAction:Wix4MessageQueuingExecuteInstall_A64\t3073\tWix4MsmqCA_A64\tMessageQueuingExecuteInstall\t",
@@ -25,7 +26,11 @@ namespace WixToolsetTest.Msmq
                 "CustomAction:Wix4MessageQueuingRollbackInstall_A64\t3329\tWix4MsmqCA_A64\tMessageQueuingRollbackInstall\t",
                 "CustomAction:Wix4MessageQueuingRollbackUninstall_A64\t3329\tWix4MsmqCA_A64\tMessageQueuingRollbackUninstall\t",
                 "CustomAction:Wix4MessageQueuingUninstall_A64\t1\tWix4MsmqCA_A64\tMessageQueuingUninstall\t",
+                "Wix4Group:TestGroup\t\tTestGroup\t",
                 "Wix4MessageQueue:TestMQ\tfilF5_pLhBuF5b4N9XEo52g_hUM5Lo\t\t\tMQLabel\t\tMQPath\t\t\t\t0",
+                "Wix4MessageQueueGroupPermission:TestMQ_TestGroup\tfilF5_pLhBuF5b4N9XEo52g_hUM5Lo\tTestMQ\tTestGroup\t160",
+                "Wix4MessageQueueUserPermission:TestMQ_TestUser\tfilF5_pLhBuF5b4N9XEo52g_hUM5Lo\tTestMQ\tTestUser\t160",
+                "Wix4User:TestUser\t\tTestUser\t\t\t\t0",
             }, results);
         }
 

--- a/src/ext/Msmq/test/WixToolsetTest.Msmq/TestData/UsingMessageQueue/PackageComponents.wxs
+++ b/src/ext/Msmq/test/WixToolsetTest.Msmq/TestData/UsingMessageQueue/PackageComponents.wxs
@@ -1,11 +1,17 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs"
-     xmlns:msmq="http://wixtoolset.org/schemas/v4/wxs/msmq">
+     xmlns:msmq="http://wixtoolset.org/schemas/v4/wxs/msmq"
+     xmlns:util="http://wixtoolset.org/schemas/v4/wxs/util">
   <Fragment>
+    <util:Group Id="TestGroup" Name="TestGroup" />
+    <util:User Id="TestUser" Name="TestUser" />
     <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
         <Component>
             <File Source="example.txt" />
-            <msmq:MessageQueue Id="TestMQ" Label="MQLabel" PathName="MQPath" />
+            <msmq:MessageQueue Id="TestMQ" Label="MQLabel" PathName="MQPath" >
+                <msmq:MessageQueuePermission Id="TestMQ_TestGroup" GetQueuePermissions="yes" GetQueueProperties="yes" Group="TestGroup" />
+                <msmq:MessageQueuePermission Id="TestMQ_TestUser" GetQueuePermissions="yes" GetQueueProperties="yes" User="TestUser" />
+            </msmq:MessageQueue>
         </Component>
     </ComponentGroup>
   </Fragment>

--- a/src/ext/Msmq/test/WixToolsetTest.Msmq/WixToolsetTest.Msmq.csproj
+++ b/src/ext/Msmq/test/WixToolsetTest.Msmq/WixToolsetTest.Msmq.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\wixext\WixToolset.Msmq.wixext.csproj" />
+    <ProjectReference Include="..\..\..\Util\wixext\WixToolset.Util.wixext.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ext/Msmq/test/WixToolsetTest.Msmq/WixToolsetTest.Msmq.csproj
+++ b/src/ext/Msmq/test/WixToolsetTest.Msmq/WixToolsetTest.Msmq.csproj
@@ -16,7 +16,6 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\wixext\WixToolset.Msmq.wixext.csproj" />
-    <ProjectReference Include="..\..\..\Util\wixext\WixToolset.Util.wixext.csproj" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ext/Msmq/wixext/MsmqDecompiler.cs
+++ b/src/ext/Msmq/wixext/MsmqDecompiler.cs
@@ -144,17 +144,17 @@ namespace WixToolset.Msmq
 
                 if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueueAttributes.Authenticate))
                 {
-                    messageQueue.Add(new XAttribute("Authenticate", YesNoType.Yes));
+                    messageQueue.Add(new XAttribute("Authenticate", "yes"));
                 }
 
                 if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueueAttributes.Journal))
                 {
-                    messageQueue.Add(new XAttribute("Journal", YesNoType.Yes));
+                    messageQueue.Add(new XAttribute("Journal", "yes"));
                 }
 
                 if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueueAttributes.Transactional))
                 {
-                    messageQueue.Add(new XAttribute("Transactional", YesNoType.Yes));
+                    messageQueue.Add(new XAttribute("Transactional", "yes"));
                 }
 
                 this.DecompilerHelper.IndexElement(row, messageQueue);
@@ -337,82 +337,82 @@ namespace WixToolset.Msmq
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.DeleteMessage))
             {
-                element.Add("DeleteMessage", YesNoType.Yes);
+                element.Add(new XAttribute("DeleteMessage", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.PeekMessage))
             {
-                element.Add("PeekMessage", YesNoType.Yes);
+                element.Add(new XAttribute("PeekMessage", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.WriteMessage))
             {
-                element.Add("WriteMessage", YesNoType.Yes);
+                element.Add(new XAttribute("WriteMessage", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.DeleteJournalMessage))
             {
-                element.Add("DeleteJournalMessage", YesNoType.Yes);
+                element.Add(new XAttribute("DeleteJournalMessage", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.SetQueueProperties))
             {
-                element.Add("SetQueueProperties", YesNoType.Yes);
+                element.Add(new XAttribute("SetQueueProperties", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.GetQueueProperties))
             {
-                element.Add("GetQueueProperties", YesNoType.Yes);
+                element.Add(new XAttribute("GetQueueProperties", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.DeleteQueue))
             {
-                element.Add("DeleteQueue", YesNoType.Yes);
+                element.Add(new XAttribute("DeleteQueue", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.GetQueuePermissions))
             {
-                element.Add("GetQueuePermissions", YesNoType.Yes);
+                element.Add(new XAttribute("GetQueuePermissions", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.ChangeQueuePermissions))
             {
-                element.Add("ChangeQueuePermissions", YesNoType.Yes);
+                element.Add(new XAttribute("ChangeQueuePermissions", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.TakeQueueOwnership))
             {
-                element.Add("TakeQueueOwnership", YesNoType.Yes);
+                element.Add(new XAttribute("TakeQueueOwnership", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.ReceiveMessage))
             {
-                element.Add("ReceiveMessage", YesNoType.Yes);
+                element.Add(new XAttribute("ReceiveMessage", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.ReceiveJournalMessage))
             {
-                element.Add("ReceiveJournalMessage", YesNoType.Yes);
+                element.Add(new XAttribute("ReceiveJournalMessage", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.QueueGenericRead))
             {
-                element.Add("QueueGenericRead", YesNoType.Yes);
+                element.Add(new XAttribute("QueueGenericRead", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.QueueGenericWrite))
             {
-                element.Add("QueueGenericWrite", YesNoType.Yes);
+                element.Add(new XAttribute("QueueGenericWrite", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.QueueGenericExecute))
             {
-                element.Add("QueueGenericExecute", YesNoType.Yes);
+                element.Add(new XAttribute("QueueGenericExecute", "yes"));
             }
 
             if (0 != (attributes & (int)MsmqCompiler.MqiMessageQueuePermission.QueueGenericAll))
             {
-                element.Add("QueueGenericAll", YesNoType.Yes);
+                element.Add(new XAttribute("QueueGenericAll", "yes"));
             }
         }
     }

--- a/src/ext/Msmq/wixext/MsmqExtensionFactory.cs
+++ b/src/ext/Msmq/wixext/MsmqExtensionFactory.cs
@@ -11,6 +11,7 @@ namespace WixToolset.Msmq
         protected override IReadOnlyCollection<Type> ExtensionTypes => new[]
         {
             typeof(MsmqCompiler),
+            typeof(MsmqDecompiler),
             typeof(MsmqExtensionData),
             typeof(MsmqWindowsInstallerBackendBinderExtension),
         };

--- a/src/ext/Msmq/wixext/MsmqTableDefinitions.cs
+++ b/src/ext/Msmq/wixext/MsmqTableDefinitions.cs
@@ -34,7 +34,7 @@ namespace WixToolset.Msmq
                 new ColumnDefinition("MessageQueueUserPermission", ColumnType.String, 72, primaryKey: true, nullable: false, ColumnCategory.Identifier, modularizeType: ColumnModularizeType.Column),
                 new ColumnDefinition("Component_", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, keyTable: "Component", keyColumn: 1, modularizeType: ColumnModularizeType.Column),
                 new ColumnDefinition("MessageQueue_", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, keyTable: "Wix4MessageQueue", keyColumn: 1, modularizeType: ColumnModularizeType.Column),
-                new ColumnDefinition("User_", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, modularizeType: ColumnModularizeType.Column),
+                new ColumnDefinition("User_", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, keyTable: "Wix4User", keyColumn: 1, modularizeType: ColumnModularizeType.Column),
                 new ColumnDefinition("Permissions", ColumnType.Number, 4, primaryKey: false, nullable: false, ColumnCategory.Unknown),
             },
             symbolIdIsPrimaryKey: true
@@ -48,7 +48,7 @@ namespace WixToolset.Msmq
                 new ColumnDefinition("MessageQueueGroupPermission", ColumnType.String, 72, primaryKey: true, nullable: false, ColumnCategory.Identifier, modularizeType: ColumnModularizeType.Column),
                 new ColumnDefinition("Component_", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, keyTable: "Component", keyColumn: 1, modularizeType: ColumnModularizeType.Column),
                 new ColumnDefinition("MessageQueue_", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, keyTable: "Wix4MessageQueue", keyColumn: 1, modularizeType: ColumnModularizeType.Column),
-                new ColumnDefinition("Group_", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, modularizeType: ColumnModularizeType.Column),
+                new ColumnDefinition("Group_", ColumnType.String, 72, primaryKey: false, nullable: false, ColumnCategory.Identifier, keyTable: "Wix4Group", keyColumn: 1, modularizeType: ColumnModularizeType.Column),
                 new ColumnDefinition("Permissions", ColumnType.Number, 4, primaryKey: false, nullable: false, ColumnCategory.Unknown),
             },
             symbolIdIsPrimaryKey: true

--- a/src/ext/Util/wixext/UtilDecompiler.cs
+++ b/src/ext/Util/wixext/UtilDecompiler.cs
@@ -455,7 +455,9 @@ namespace WixToolset.Util
             foreach (var row in table.Rows)
             {
                 var groupId = row.FieldAsString(0);
-                if (this.DecompilerHelper.TryGetIndexedElement("Group", groupId, out var group))
+                XElement group;
+                if (this.DecompilerHelper.TryGetIndexedElement("Group", groupId, out group)
+                    || this.DecompilerHelper.TryGetIndexedElement("Wix4Group", groupId, out group))
                 {
                     var attributes = (Group6SymbolAttributes)(row.FieldAsNullableInteger(2) ?? 0);
                     group.Add(AttributeIfNotNull("Comment", row, 1));
@@ -483,10 +485,14 @@ namespace WixToolset.Util
             foreach (var row in table.Rows)
             {
                 var parentId = row.FieldAsString(0);
-                var parentExists = this.DecompilerHelper.TryGetIndexedElement("Group", parentId, out var parentGroup);
+                XElement parentGroup;
+                var parentExists = (this.DecompilerHelper.TryGetIndexedElement("Group", parentId, out parentGroup)
+                        || this.DecompilerHelper.TryGetIndexedElement("Wix4Group", parentId, out parentGroup));
 
                 var childId = row.FieldAsString(1);
-                var childExists = this.DecompilerHelper.TryGetIndexedElement("Group", childId, out var childGroup);
+                XElement childGroup;
+                var childExists = (this.DecompilerHelper.TryGetIndexedElement("Group", childId, out childGroup)
+                        || this.DecompilerHelper.TryGetIndexedElement("Wix4Group", childId, out childGroup));
 
                 if (parentExists && childExists)
                 {

--- a/src/ext/Util/wixext/UtilDecompiler.cs
+++ b/src/ext/Util/wixext/UtilDecompiler.cs
@@ -435,11 +435,15 @@ namespace WixToolset.Util
         {
             foreach (var row in table.Rows)
             {
-                this.DecompilerHelper.AddElementToRoot(UtilConstants.GroupName,
+                var group = new XElement(UtilConstants.GroupName,
                     new XAttribute("Id", row.FieldAsString(0)),
                     new XAttribute("Name", row.FieldAsString(2)),
                     AttributeIfNotNull("Domain", row, 3)
                     );
+
+                this.DecompilerHelper.AddElementToRoot(group);
+
+                this.DecompilerHelper.IndexElement(row, group);
             }
         }
         /// <summary>


### PR DESCRIPTION
Fix up missing 'Wix4' prefixes on MSMQ Permission tables.
And updated decompiler to Wix4 table names etc in line with firewall CA.

Fixes wixtoolset/issues#8902