### PR TITLE
Backward compatible GUID generation and validate that generated GUIDs don't change

### DIFF
--- a/src/api/wix/WixToolset.Extensibility/Data/IBindContext.cs
+++ b/src/api/wix/WixToolset.Extensibility/Data/IBindContext.cs
@@ -18,6 +18,11 @@ namespace WixToolset.Extensibility.Data
         IServiceProvider ServiceProvider { get; }
 
         /// <summary>
+        /// Indicates whether to generate GUIDs backward compatible with WiX v3.
+        /// </summary>
+        bool BackwardCompatibleGuidGeneration { get; set; }
+
+        /// <summary>
         /// Bind paths used during resolution.
         /// </summary>
         IReadOnlyCollection<IBindPath> BindPaths { get; set; }

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/BindDatabaseCommand.cs
@@ -32,6 +32,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
             this.FileSystem = context.ServiceProvider.GetService<IFileSystem>();
             this.PathResolver = context.ServiceProvider.GetService<IPathResolver>();
 
+            this.BackwardCompatibleGuidGeneration = context.BackwardCompatibleGuidGeneration;
             this.CabbingThreadCount = context.CabbingThreadCount;
             this.CabCachePath = context.CabCachePath;
             this.DefaultCompressionLevel = context.DefaultCompressionLevel;
@@ -64,6 +65,8 @@ namespace WixToolset.Core.WindowsInstaller.Bind
         private IFileSystem FileSystem { get; }
 
         private IPathResolver PathResolver { get; }
+
+        private bool BackwardCompatibleGuidGeneration { get; }
 
         private int CabbingThreadCount { get; }
 
@@ -410,7 +413,7 @@ namespace WixToolset.Core.WindowsInstaller.Bind
 
             // Set generated component guids and validate all guids.
             {
-                var command = new FinalizeComponentGuids(this.Messaging, this.WindowsInstallerBackendHelper, this.PathResolver, section, platform);
+                var command = new FinalizeComponentGuids(this.Messaging, this.WindowsInstallerBackendHelper, this.PathResolver, section, platform, this.BackwardCompatibleGuidGeneration);
                 command.Execute();
             }
 

--- a/src/wix/WixToolset.Core.WindowsInstaller/Bind/FinalizeComponentGuids.cs
+++ b/src/wix/WixToolset.Core.WindowsInstaller/Bind/FinalizeComponentGuids.cs
@@ -16,13 +16,14 @@ namespace WixToolset.Core.WindowsInstaller.Bind
     /// </summary>
     internal class FinalizeComponentGuids
     {
-        internal FinalizeComponentGuids(IMessaging messaging, IBackendHelper helper, IPathResolver pathResolver, IntermediateSection section, Platform platform)
+        internal FinalizeComponentGuids(IMessaging messaging, IBackendHelper helper, IPathResolver pathResolver, IntermediateSection section, Platform platform, bool backwardCompatibleGuidGeneration)
         {
             this.Messaging = messaging;
             this.BackendHelper = helper;
             this.PathResolver = pathResolver;
             this.Section = section;
             this.Platform = platform;
+            this.BackwardCompatibleGuidGeneration = backwardCompatibleGuidGeneration;
         }
 
         private IMessaging Messaging { get; }
@@ -34,6 +35,8 @@ namespace WixToolset.Core.WindowsInstaller.Bind
         private IntermediateSection Section { get; }
 
         private Platform Platform { get; }
+
+        private  bool BackwardCompatibleGuidGeneration { get; }
 
         private Dictionary<string, string> ComponentIdGenSeeds { get; set; }
 
@@ -98,7 +101,9 @@ namespace WixToolset.Core.WindowsInstaller.Bind
                 if (this.RegistrySymbolsById.TryGetValue(componentSymbol.KeyPath, out var registrySymbol))
                 {
                     var bitness = componentSymbol.Win64 ? "64" : String.Empty;
-                    var regkey = String.Concat(bitness, registrySymbol.Root, "\\", registrySymbol.Key, "\\", registrySymbol.Name);
+                    var regkey = this.BackwardCompatibleGuidGeneration ?
+                        String.Concat(bitness, (int)registrySymbol.Root, "\\", registrySymbol.Key, "\\", registrySymbol.Name) :
+                        String.Concat(bitness, registrySymbol.Root, "\\", registrySymbol.Key, "\\", registrySymbol.Name);
                     componentSymbol.ComponentId = this.BackendHelper.CreateGuid(BindDatabaseCommand.WixComponentGuidNamespace, regkey.ToLowerInvariant());
                 }
             }

--- a/src/wix/WixToolset.Core/BindContext.cs
+++ b/src/wix/WixToolset.Core/BindContext.cs
@@ -22,6 +22,8 @@ namespace WixToolset.Core
 
         public string BurnStubPath { get; set; }
 
+        public bool BackwardCompatibleGuidGeneration { get; set; }
+
         public int CabbingThreadCount { get; set; }
 
         public string CabCachePath { get; set; }

--- a/src/wix/test/WixToolsetTest.CoreIntegration/GuidCompatibilityFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/GuidCompatibilityFixture.cs
@@ -1,0 +1,238 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+namespace WixToolsetTest.CoreIntegration
+{
+    using System.IO;
+    using System.Linq;
+    using WixInternal.Core.TestPackage;
+    using WixInternal.TestSupport;
+    using WixToolset.Data;
+    using WixToolset.Data.Symbols;
+    using Xunit;
+
+    public class GuidCompatibilityFixture
+    {
+        [Fact]
+        public void VerifyModernX86GuidCompatibility()
+        {
+            var folder = TestData.Get("TestData", "GuidCompatibility");
+
+            using var fs = new DisposableFileSystem();
+
+            var baseFolder = fs.GetFolder();
+            var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+            var result = WixRunner.Execute(new[]
+            {
+                "build",
+                Path.Combine(folder, "Package.wxs"),
+                Path.Combine(folder, "Components.wxs"),
+                "-intermediateFolder", intermediateFolder,
+                "-o", Path.Combine(baseFolder, "bin", "test.msi")
+            });
+
+            result.AssertSuccess();
+
+            var wixpdb = Intermediate.Load(Path.Combine(baseFolder, "bin", "test.wixpdb"));
+            var section = wixpdb.Sections.Single();
+
+            var symbols = section.Symbols.OfType<ComponentSymbol>().ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                "FileFoo {AD87A3DE-042B-5CB1-82C8-782626737A3B} File:filrCrmOAxegUXdKLQjj8mKJFZC2AY",
+                "RegHkcr {246B5173-0924-511B-8828-77DD3BE87C7D} Registry:regYqKbt2o5W7y7CIBKba5Du9MJ2xU",
+                "RegHkcu {663BDBDA-FAAF-5B7A-B8BA-D1AB3B5284CD} Registry:regCDVjmO6qHBvQzdqM8XyBiEUuf48",
+                "RegHklm {6A5C002D-C0C9-5B03-B883-BE3DF3FA21A6} Registry:regPKV64nTdbwlRm8bkU8k4Kxj6Km8",
+                "RegHkmu {529D5485-ED3E-5D1C-8517-A32103A08F76} Registry:regOPf4kOF1RLKsRy9oG4MP1Rqm8JY",
+                "RegHku {0C78D91F-7913-5747-918C-322DA2A15823} Registry:regJHg773M8wPDSk6j7CYRThPX7uOw"
+            }, symbols.Select(s => $"{s.Id.Id} {s.ComponentId} {s.KeyPathType}:{s.KeyPath}").OrderBy(s => s).ToArray());
+        }
+
+        [Fact]
+        public void VerifyModernX64GuidCompatibility()
+        {
+            var folder = TestData.Get("TestData", "GuidCompatibility");
+
+            using var fs = new DisposableFileSystem();
+
+            var baseFolder = fs.GetFolder();
+            var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+            var result = WixRunner.Execute(new[]
+            {
+                "build",
+                Path.Combine(folder, "Package.wxs"),
+                Path.Combine(folder, "Components.wxs"),
+                "-arch", "x64",
+                "-intermediateFolder", intermediateFolder,
+                "-o", Path.Combine(baseFolder, "bin", "test.msi")
+            });
+
+            result.AssertSuccess();
+
+            var wixpdb = Intermediate.Load(Path.Combine(baseFolder, "bin", "test.wixpdb"));
+            var section = wixpdb.Sections.Single();
+
+            var symbols = section.Symbols.OfType<ComponentSymbol>().ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                "FileFoo {AD87A3DE-042B-5CB1-82C8-782626737A3B} File:filrCrmOAxegUXdKLQjj8mKJFZC2AY",
+                "RegHkcr {A2D16D0D-8856-5B34-804F-64E0EE691ACD} Registry:regYqKbt2o5W7y7CIBKba5Du9MJ2xU",
+                "RegHkcu {CE5B9399-8F69-50E4-AE76-9F5C3F5A4D72} Registry:regCDVjmO6qHBvQzdqM8XyBiEUuf48",
+                "RegHklm {45973AE0-BFEF-5A88-AC82-416C9699ED23} Registry:regPKV64nTdbwlRm8bkU8k4Kxj6Km8",
+                "RegHkmu {841288A2-7520-5CA5-8CA0-4B4711D3F669} Registry:regOPf4kOF1RLKsRy9oG4MP1Rqm8JY",
+                "RegHku {0AC9C5B2-E60A-5CD9-9A4E-B5DEABAD1D14} Registry:regJHg773M8wPDSk6j7CYRThPX7uOw"
+            }, symbols.Select(s => $"{s.Id.Id} {s.ComponentId} {s.KeyPathType}:{s.KeyPath}").OrderBy(s => s).ToArray());
+        }
+
+        [Fact]
+        public void VerifyModernArm64GuidCompatibility()
+        {
+            var folder = TestData.Get("TestData", "GuidCompatibility");
+
+            using var fs = new DisposableFileSystem();
+
+            var baseFolder = fs.GetFolder();
+            var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+            var result = WixRunner.Execute(new[]
+            {
+                "build",
+                Path.Combine(folder, "Package.wxs"),
+                Path.Combine(folder, "Components.wxs"),
+                "-arch", "arm64",
+                "-intermediateFolder", intermediateFolder,
+                "-o", Path.Combine(baseFolder, "bin", "test.msi")
+            });
+
+            result.AssertSuccess();
+
+            var wixpdb = Intermediate.Load(Path.Combine(baseFolder, "bin", "test.wixpdb"));
+            var section = wixpdb.Sections.Single();
+
+            var symbols = section.Symbols.OfType<ComponentSymbol>().ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                "FileFoo {AD87A3DE-042B-5CB1-82C8-782626737A3B} File:filrCrmOAxegUXdKLQjj8mKJFZC2AY",
+                "RegHkcr {A2D16D0D-8856-5B34-804F-64E0EE691ACD} Registry:regYqKbt2o5W7y7CIBKba5Du9MJ2xU",
+                "RegHkcu {CE5B9399-8F69-50E4-AE76-9F5C3F5A4D72} Registry:regCDVjmO6qHBvQzdqM8XyBiEUuf48",
+                "RegHklm {45973AE0-BFEF-5A88-AC82-416C9699ED23} Registry:regPKV64nTdbwlRm8bkU8k4Kxj6Km8",
+                "RegHkmu {841288A2-7520-5CA5-8CA0-4B4711D3F669} Registry:regOPf4kOF1RLKsRy9oG4MP1Rqm8JY",
+                "RegHku {0AC9C5B2-E60A-5CD9-9A4E-B5DEABAD1D14} Registry:regJHg773M8wPDSk6j7CYRThPX7uOw"
+            }, symbols.Select(s => $"{s.Id.Id} {s.ComponentId} {s.KeyPathType}:{s.KeyPath}").OrderBy(s => s).ToArray());
+        }
+
+        [Fact]
+        public void VerifyWix3X86GuidCompatibility()
+        {
+            var folder = TestData.Get("TestData", "GuidCompatibility");
+
+            using var fs = new DisposableFileSystem();
+
+            var baseFolder = fs.GetFolder();
+            var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+            var result = WixRunner.Execute(new[]
+            {
+                "build",
+                Path.Combine(folder, "Package.wxs"),
+                Path.Combine(folder, "Components.wxs"),
+                "-bcgg",
+                "-intermediateFolder", intermediateFolder,
+                "-o", Path.Combine(baseFolder, "bin", "test.msi")
+            });
+
+            result.AssertSuccess();
+
+            var wixpdb = Intermediate.Load(Path.Combine(baseFolder, "bin", "test.wixpdb"));
+            var section = wixpdb.Sections.Single();
+
+            var symbols = section.Symbols.OfType<ComponentSymbol>().ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                "FileFoo {AD87A3DE-042B-5CB1-82C8-782626737A3B} File:filrCrmOAxegUXdKLQjj8mKJFZC2AY",
+                "RegHkcr {656550C1-E3C3-5943-900A-A286A24F1F7C} Registry:regYqKbt2o5W7y7CIBKba5Du9MJ2xU",
+                "RegHkcu {5C7CBEDE-4C14-58AF-8365-59C602A20543} Registry:regCDVjmO6qHBvQzdqM8XyBiEUuf48",
+                "RegHklm {186E35F4-96E9-5DE4-8F7B-73EA096A8543} Registry:regPKV64nTdbwlRm8bkU8k4Kxj6Km8",
+                "RegHkmu {C1707072-2C2C-5249-85E1-37418A31DF2D} Registry:regOPf4kOF1RLKsRy9oG4MP1Rqm8JY",
+                "RegHku {76A0D3F4-7BD5-51DE-8FDA-6C30674083CB} Registry:regJHg773M8wPDSk6j7CYRThPX7uOw"
+            }, symbols.Select(s => $"{s.Id.Id} {s.ComponentId} {s.KeyPathType}:{s.KeyPath}").OrderBy(s => s).ToArray());
+        }
+
+        [Fact]
+        public void VerifyWix3X64GuidCompatibility()
+        {
+            var folder = TestData.Get("TestData", "GuidCompatibility");
+
+            using var fs = new DisposableFileSystem();
+
+            var baseFolder = fs.GetFolder();
+            var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+            var result = WixRunner.Execute(new[]
+            {
+                "build",
+                Path.Combine(folder, "Package.wxs"),
+                Path.Combine(folder, "Components.wxs"),
+                "-bcgg",
+                "-arch", "x64",
+                "-intermediateFolder", intermediateFolder,
+                "-o", Path.Combine(baseFolder, "bin", "test.msi")
+            });
+
+            result.AssertSuccess();
+
+            var wixpdb = Intermediate.Load(Path.Combine(baseFolder, "bin", "test.wixpdb"));
+            var section = wixpdb.Sections.Single();
+
+            var symbols = section.Symbols.OfType<ComponentSymbol>().ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                "FileFoo {AD87A3DE-042B-5CB1-82C8-782626737A3B} File:filrCrmOAxegUXdKLQjj8mKJFZC2AY",
+                "RegHkcr {E420B3FC-4889-5D2B-8E2D-DC8D05B62B5B} Registry:regYqKbt2o5W7y7CIBKba5Du9MJ2xU",
+                "RegHkcu {12D81E73-4429-5D97-8318-7E719F660847} Registry:regCDVjmO6qHBvQzdqM8XyBiEUuf48",
+                "RegHklm {2E7AA7BE-006C-5FFE-A73F-1C65142AB3D7} Registry:regPKV64nTdbwlRm8bkU8k4Kxj6Km8",
+                "RegHkmu {C7972BDE-CA76-564D-A9BA-FD3A0B930DCF} Registry:regOPf4kOF1RLKsRy9oG4MP1Rqm8JY",
+                "RegHku {AB4A2008-03FC-513E-8B92-35CE837C212E} Registry:regJHg773M8wPDSk6j7CYRThPX7uOw"
+            }, symbols.Select(s => $"{s.Id.Id} {s.ComponentId} {s.KeyPathType}:{s.KeyPath}").OrderBy(s => s).ToArray());
+        }
+
+        [Fact]
+        public void VerifyWix3Arm64GuidCompatibility()
+        {
+            var folder = TestData.Get("TestData", "GuidCompatibility");
+
+            using var fs = new DisposableFileSystem();
+
+            var baseFolder = fs.GetFolder();
+            var intermediateFolder = Path.Combine(baseFolder, "obj");
+
+            var result = WixRunner.Execute(new[]
+            {
+                "build",
+                Path.Combine(folder, "Package.wxs"),
+                Path.Combine(folder, "Components.wxs"),
+                "-bcgg",
+                "-arch", "x64",
+                "-intermediateFolder", intermediateFolder,
+                "-o", Path.Combine(baseFolder, "bin", "test.msi")
+            });
+
+            result.AssertSuccess();
+
+            var wixpdb = Intermediate.Load(Path.Combine(baseFolder, "bin", "test.wixpdb"));
+            var section = wixpdb.Sections.Single();
+
+            var symbols = section.Symbols.OfType<ComponentSymbol>().ToArray();
+            WixAssert.CompareLineByLine(new[]
+            {
+                "FileFoo {AD87A3DE-042B-5CB1-82C8-782626737A3B} File:filrCrmOAxegUXdKLQjj8mKJFZC2AY",
+                "RegHkcr {E420B3FC-4889-5D2B-8E2D-DC8D05B62B5B} Registry:regYqKbt2o5W7y7CIBKba5Du9MJ2xU",
+                "RegHkcu {12D81E73-4429-5D97-8318-7E719F660847} Registry:regCDVjmO6qHBvQzdqM8XyBiEUuf48",
+                "RegHklm {2E7AA7BE-006C-5FFE-A73F-1C65142AB3D7} Registry:regPKV64nTdbwlRm8bkU8k4Kxj6Km8",
+                "RegHkmu {C7972BDE-CA76-564D-A9BA-FD3A0B930DCF} Registry:regOPf4kOF1RLKsRy9oG4MP1Rqm8JY",
+                "RegHku {AB4A2008-03FC-513E-8B92-35CE837C212E} Registry:regJHg773M8wPDSk6j7CYRThPX7uOw"
+            }, symbols.Select(s => $"{s.Id.Id} {s.ComponentId} {s.KeyPathType}:{s.KeyPath}").OrderBy(s => s).ToArray());
+        }
+    }
+}

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/GuidCompatibility/Components.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/GuidCompatibility/Components.wxs
@@ -1,0 +1,29 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+      <Component Id="FileFoo">
+        <File Name="Foo.bar" Source="$(sys.SOURCEFILEPATH)" />
+      </Component>
+
+      <Component Id="RegHklm">
+        <RegistryValue Root="HKLM" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+
+      <Component Id="RegHkcr">
+        <RegistryValue Root="HKCR" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+
+      <Component Id="RegHkcu">
+        <RegistryValue Root="HKCU" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+
+      <Component Id="RegHkmu">
+        <RegistryValue Root="HKMU" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+
+      <Component Id="RegHku">
+        <RegistryValue Root="HKU" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/GuidCompatibility/Package.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/GuidCompatibility/Package.wxs
@@ -1,0 +1,14 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+  <Package Id="WixToolsetTest.TestPackage" Name="GuidCompatibility" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" Compressed="no">
+
+    <Feature Id="ProductFeature">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Package>
+
+  <Fragment>
+    <StandardDirectory Id="ProgramFilesFolder">
+      <Directory Id="INSTALLFOLDER" Name="GuidCompatibility" />
+    </StandardDirectory>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/GuidCompatibility/Wix3Components.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/GuidCompatibility/Wix3Components.wxs
@@ -1,0 +1,29 @@
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER">
+      <Component Id="FileFoo">
+        <File Name="Foo.bar" Source="$(sys.SOURCEFILEPATH)" />
+      </Component>
+
+      <Component Id="RegHklm">
+        <RegistryValue Root="HKLM" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+
+      <Component Id="RegHkcr">
+        <RegistryValue Root="HKCR" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+
+      <Component Id="RegHkcu">
+        <RegistryValue Root="HKCU" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+
+      <Component Id="RegHkmu">
+        <RegistryValue Root="HKMU" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+
+      <Component Id="RegHku">
+        <RegistryValue Root="HKU" Key="WixToolset\TestKey" Name="Compat" Value="Foo Bar" Type="string"/>
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/GuidCompatibility/Wix3Product.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/GuidCompatibility/Wix3Product.wxs
@@ -1,0 +1,19 @@
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <Product Id="*" Name="GuidCompatibility" Language="1033" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="AD87A3DE-042B-5CB1-82C8-782626737A3B">
+    <Package />
+    <MajorUpgrade DowngradeErrorMessage="No" />
+    <MediaTemplate />
+
+    <Feature Id="ProductFeature">
+      <ComponentGroupRef Id="ProductComponents" />
+    </Feature>
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="ProgramFilesFolder">
+        <Directory Id="INSTALLFOLDER" Name="GuidCompatibility" />
+      </Directory>
+    </Directory>
+  </Fragment>
+</Wix>


### PR DESCRIPTION
* Backward compatible GUID generation - fixes wixtoolset/issues#8663 and closes #589
