### PR TITLE
Ensure user and group integration tests always clean up after themselves

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,7 @@ ScaffoldingReadMe.txt
 StyleCopReport.xml
 
 # Files built by Visual Studio
+*_i.h
 *_i.c
 *_p.c
 *_h.h

--- a/src/test/msi/WixToolsetTest.MsiE2E/UtilExtensionGroupTests.cs
+++ b/src/test/msi/WixToolsetTest.MsiE2E/UtilExtensionGroupTests.cs
@@ -16,51 +16,60 @@ namespace WixToolsetTest.MsiE2E
         [RuntimeFact]
         public void CanInstallAndUninstallNonDomainGroups()
         {
-            UserGroupVerifier.CreateLocalGroup("testName3");
-            var productA = this.CreatePackageInstaller("ProductA");
+            try
+            {
+                UserGroupVerifier.CreateLocalGroup("testName3");
+                var productA = this.CreatePackageInstaller("ProductA");
 
-            productA.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Validate New User Information.
-            Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("Group '{0}' was not created on Install", "testName1"));
-            Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("Group '{0}' was not created on Install", "testName2"));
-            Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName3"), String.Format("Group '{0}' was not created on Install", "testName3"));
+                // Validate New User Information.
+                Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("Group '{0}' was not created on Install", "testName1"));
+                Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("Group '{0}' was not created on Install", "testName2"));
+                Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName3"), String.Format("Group '{0}' was not created on Install", "testName3"));
 
-            productA.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Verify Users marked as RemoveOnUninstall were removed.
-            Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("Group '{0}' was not removed on Uninstall", "testName1"));
-            Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("Group '{0}' was removed on Uninstall", "testName2"));
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
-            UserGroupVerifier.DeleteLocalGroup("testName2");
-            UserGroupVerifier.DeleteLocalGroup("testName3");
+                // Verify Users marked as RemoveOnUninstall were removed.
+                Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("Group '{0}' was not removed on Uninstall", "testName1"));
+                Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("Group '{0}' was removed on Uninstall", "testName2"));
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+                UserGroupVerifier.DeleteLocalGroup("testName2");
+                UserGroupVerifier.DeleteLocalGroup("testName3");
+            }
         }
 
         // Verify the rollback action reverts all Users changes.
         [RuntimeFact]
         public void CanRollbackNonDomainGroups()
         {
-            UserGroupVerifier.CreateLocalGroup("testName3");
-            var productFail = this.CreatePackageInstaller("ProductFail");
+            try
+            {
+                UserGroupVerifier.CreateLocalGroup("testName3");
+                var productFail = this.CreatePackageInstaller("ProductFail");
 
-            // make sure the user accounts are deleted before we start
-            UserGroupVerifier.DeleteLocalGroup("testName1");
-            UserGroupVerifier.DeleteLocalGroup("testName2");
+                // make sure the user accounts are deleted before we start
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+                UserGroupVerifier.DeleteLocalGroup("testName2");
 
-            productFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE);
+                productFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE);
 
-            // Verify added Users were removed on rollback.
-            Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("Group '{0}' was not removed on Rollback", "testName1"));
-            Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("Group '{0}' was not removed on Rollback", "testName2"));
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
-            UserGroupVerifier.DeleteLocalGroup("testName2");
-            UserGroupVerifier.DeleteLocalGroup("testName3");
+                // Verify added Users were removed on rollback.
+                Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("Group '{0}' was not removed on Rollback", "testName1"));
+                Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("Group '{0}' was not removed on Rollback", "testName2"));
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+                UserGroupVerifier.DeleteLocalGroup("testName2");
+                UserGroupVerifier.DeleteLocalGroup("testName3");
+            }
         }
-
 
         // Verify that command-line parameters aer not blocked by repair switches.
         // Original code signalled repair mode by using "-f ", which silently
@@ -68,58 +77,67 @@ namespace WixToolsetTest.MsiE2E
         [RuntimeFact()]
         public void CanRepairNonDomainGroupsWithCommandLineParameters()
         {
-            var arguments = new string[]
+            try
             {
-                "TESTPARAMETER1=testName1",
-            };
-            var productWithCommandLineParameters = this.CreatePackageInstaller("ProductWithCommandLineParameters");
+                var arguments = new string[]
+                {
+                    "TESTPARAMETER1=testName1",
+                };
+                var productWithCommandLineParameters = this.CreatePackageInstaller("ProductWithCommandLineParameters");
 
-            // Make sure that the user doesn't exist when we start the test.
-            UserGroupVerifier.DeleteLocalGroup("testName1");
+                // Make sure that the user doesn't exist when we start the test.
+                UserGroupVerifier.DeleteLocalGroup("testName1");
 
-            // Install
-            productWithCommandLineParameters.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
+                // Install
+                productWithCommandLineParameters.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
 
-            // Repair
-            productWithCommandLineParameters.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
+                // Repair
+                productWithCommandLineParameters.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
 
 
-            // Install
-            productWithCommandLineParameters.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
-
-            // Clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
+                // Install
+                productWithCommandLineParameters.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
+            }
+            finally
+            {
+                // Clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+            }
         }
-
 
         // Verify that the groups specified in the authoring are created as expected on repair.
         [RuntimeFact()]
         public void CanRepairNonDomainGroups()
         {
-            UserGroupVerifier.CreateLocalGroup("testName3");
-            var productA = this.CreatePackageInstaller("ProductA");
+            try
+            {
+                UserGroupVerifier.CreateLocalGroup("testName3");
+                var productA = this.CreatePackageInstaller("ProductA");
 
-            productA.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Validate New User Information.
-            UserGroupVerifier.DeleteLocalGroup("testName1");
+                // Validate New User Information.
+                UserGroupVerifier.DeleteLocalGroup("testName1");
 
-            productA.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Validate New User Information.
-            Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("User '{0}' was not installed on Repair", "testName1"));
-            Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("User '{0}' was not installed after Repair", "testName2"));
+                // Validate New User Information.
+                Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("User '{0}' was not installed on Repair", "testName1"));
+                Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("User '{0}' was not installed after Repair", "testName2"));
 
-            productA.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Verify Users marked as RemoveOnUninstall were removed.
-            Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("User '{0}' was not removed on Uninstall", "testName1"));
-            Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("User '{0}' was removed on Uninstall", "testName2"));
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
-            UserGroupVerifier.DeleteLocalGroup("testName2");
-            UserGroupVerifier.DeleteLocalGroup("testName3");
+                // Verify Users marked as RemoveOnUninstall were removed.
+                Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("User '{0}' was not removed on Uninstall", "testName1"));
+                Assert.True(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("User '{0}' was removed on Uninstall", "testName2"));
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+                UserGroupVerifier.DeleteLocalGroup("testName2");
+                UserGroupVerifier.DeleteLocalGroup("testName3");
+            }
         }
 
         // Verify that Installation fails if FailIfExists is set.
@@ -165,101 +183,131 @@ namespace WixToolsetTest.MsiE2E
         [RuntimeFact]
         public void CanCreateNewNonDomainGroupWithComment()
         {
-            var productNewUserWithComment = this.CreatePackageInstaller("ProductNewGroupWithComment");
+            try
+            {
+                var productNewUserWithComment = this.CreatePackageInstaller("ProductNewGroupWithComment");
 
-            productNewUserWithComment.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
-            UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "testComment1");
-            productNewUserWithComment.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
+                productNewUserWithComment.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "testComment1");
+                productNewUserWithComment.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+            }
         }
 
         // Verify that a comment can be added to an existing group
         [RuntimeFact]
         public void CanAddCommentToExistingNonDomainGroup()
         {
-            UserGroupVerifier.CreateLocalGroup("testName1");
-            var productAddCommentToExistingUser = this.CreatePackageInstaller("ProductAddCommentToExistingGroup");
+            try
+            {
+                UserGroupVerifier.CreateLocalGroup("testName1");
+                var productAddCommentToExistingUser = this.CreatePackageInstaller("ProductAddCommentToExistingGroup");
 
-            productAddCommentToExistingUser.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productAddCommentToExistingUser.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "testComment1");
+                UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "testComment1");
 
-            productAddCommentToExistingUser.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
+                productAddCommentToExistingUser.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+            }
         }
 
         // Verify that a comment can be repaired for a new group
         [RuntimeFact]
         public void CanRepairCommentOfNewNonDomainGroup()
         {
-            var productNewUserWithComment = this.CreatePackageInstaller("ProductNewGroupWithComment");
+            try
+            {
+                var productNewUserWithComment = this.CreatePackageInstaller("ProductNewGroupWithComment");
 
-            productNewUserWithComment.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
-            UserGroupVerifier.SetGroupComment(String.Empty, "testName1", "");
+                productNewUserWithComment.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                UserGroupVerifier.SetGroupComment(String.Empty, "testName1", "");
 
-            productNewUserWithComment.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS);
-            UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "testComment1");
-            productNewUserWithComment.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
+                productNewUserWithComment.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "testComment1");
+                productNewUserWithComment.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+            }
         }
 
         // Verify that a comment can be changed for an existing group
         [RuntimeFact]
         public void CanChangeCommentOfExistingNonDomainGroup()
         {
-            UserGroupVerifier.CreateLocalGroup("testName1");
-            UserGroupVerifier.SetGroupComment(String.Empty, "testName1", "initialTestComment1");
-            var productNewUserWithComment = this.CreatePackageInstaller("ProductNewGroupWithComment");
+            try
+            {
+                UserGroupVerifier.CreateLocalGroup("testName1");
+                UserGroupVerifier.SetGroupComment(String.Empty, "testName1", "initialTestComment1");
+                var productNewUserWithComment = this.CreatePackageInstaller("ProductNewGroupWithComment");
 
-            productNewUserWithComment.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
-            UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "testComment1");
-            productNewUserWithComment.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
+                productNewUserWithComment.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "testComment1");
+                productNewUserWithComment.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+            }
         }
 
         // Verify that a comment can be rolled back for an existing group
         [RuntimeFact]
         public void CanRollbackCommentOfExistingNonDomainGroup()
         {
-            UserGroupVerifier.CreateLocalGroup("testName1");
-            UserGroupVerifier.SetGroupComment(String.Empty, "testName1", "initialTestComment1");
-            var productCommentFail = this.CreatePackageInstaller("ProductCommentFail");
+            try
+            {
+                UserGroupVerifier.CreateLocalGroup("testName1");
+                UserGroupVerifier.SetGroupComment(String.Empty, "testName1", "initialTestComment1");
+                var productCommentFail = this.CreatePackageInstaller("ProductCommentFail");
 
-            productCommentFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE);
+                productCommentFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE);
 
-            // Verify that comment change was rolled back.
-            UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "initialTestComment1");
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
+                // Verify that comment change was rolled back.
+                UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "initialTestComment1");
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+            }
         }
 
         // Verify that a comment can be deleted for an existing group
         [RuntimeFact]
         public void CanDeleteCommentOfExistingNonDomainGroup()
         {
-            UserGroupVerifier.CreateLocalGroup("testName1");
-            UserGroupVerifier.SetGroupComment(String.Empty, "testName1", "testComment1");
-            var productCommentDelete = this.CreatePackageInstaller("ProductCommentDelete");
+            try
+            {
+                UserGroupVerifier.CreateLocalGroup("testName1");
+                UserGroupVerifier.SetGroupComment(String.Empty, "testName1", "testComment1");
+                var productCommentDelete = this.CreatePackageInstaller("ProductCommentDelete");
 
-            productCommentDelete.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productCommentDelete.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Verify that comment was removed.
-            UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "");
+                // Verify that comment was removed.
+                UserGroupVerifier.VerifyGroupComment(String.Empty, "testName1", "");
 
 
-            productCommentDelete.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
+                productCommentDelete.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+            }
         }
 
         #endregion
@@ -269,48 +317,58 @@ namespace WixToolsetTest.MsiE2E
         [RuntimeFact(DomainRequired = true)]
         public void CanNestDomainGroups()
         {
-            var testDomain = System.Environment.UserDomainName;
-            var productNestedGroups = this.CreatePackageInstaller("ProductNestedGroups");
+            try
+            {
+                var testDomain = System.Environment.UserDomainName;
+                var productNestedGroups = this.CreatePackageInstaller("ProductNestedGroups");
 
-            productNestedGroups.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, $"TESTDOMAIN={testDomain}");
+                productNestedGroups.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, $"TESTDOMAIN={testDomain}");
 
-            // Verify group nested membership
-            UserGroupVerifier.VerifyIsMemberOf(testDomain, "Domain Users", new string[] { "testName1", "testName2" });
-            //UserGroupVerifier.VerifyIsMemberOf(String.Empty, "Everyone", new string[] { "testName1" });
+                // Verify group nested membership
+                UserGroupVerifier.VerifyIsMemberOf(testDomain, "Domain Users", new string[] { "testName1", "testName2" });
+                //UserGroupVerifier.VerifyIsMemberOf(String.Empty, "Everyone", new string[] { "testName1" });
 
-            UserGroupVerifier.VerifyIsNotMemberOf(testDomain, "Domain Users", new string[] { "testName3" });
-            //UserGroupVerifier.VerifyIsNotMemberOf(String.Empty, "Everyone", new string[] { "testName2", "testName3" });
+                UserGroupVerifier.VerifyIsNotMemberOf(testDomain, "Domain Users", new string[] { "testName3" });
+                //UserGroupVerifier.VerifyIsNotMemberOf(String.Empty, "Everyone", new string[] { "testName2", "testName3" });
 
-            productNestedGroups.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, $"TESTDOMAIN={testDomain}");
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
-            UserGroupVerifier.DeleteLocalGroup("testName2");
-            UserGroupVerifier.DeleteLocalGroup("testName3");
+                productNestedGroups.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, $"TESTDOMAIN={testDomain}");
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+                UserGroupVerifier.DeleteLocalGroup("testName2");
+                UserGroupVerifier.DeleteLocalGroup("testName3");
+            }
         }
 
         // Verify the rollback action reverts all Users changes.
         [RuntimeFact(DomainRequired = true)]
         public void CanRollbackDomainGroups()
         {
-            var testDomain = System.Environment.UserDomainName;
-            UserGroupVerifier.CreateLocalGroup("testName3");
-            var productFail = this.CreatePackageInstaller("ProductFail");
+            try
+            {
+                var testDomain = System.Environment.UserDomainName;
+                UserGroupVerifier.CreateLocalGroup("testName3");
+                var productFail = this.CreatePackageInstaller("ProductFail");
 
-            // make sure the user accounts are deleted before we start
-            UserGroupVerifier.DeleteLocalGroup("testName1");
-            UserGroupVerifier.DeleteLocalGroup("testName2");
+                // make sure the user accounts are deleted before we start
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+                UserGroupVerifier.DeleteLocalGroup("testName2");
 
-            productFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE, $"TESTDOMAIN={testDomain}");
+                productFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE, $"TESTDOMAIN={testDomain}");
 
-            // Verify added Users were removed on rollback.
-            Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("Group '{0}' was not removed on Rollback", "testName1"));
-            Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("Group '{0}' was not removed on Rollback", "testName2"));
-
-            // clean up
-            UserGroupVerifier.DeleteLocalGroup("testName1");
-            UserGroupVerifier.DeleteLocalGroup("testName2");
-            UserGroupVerifier.DeleteLocalGroup("testName3");
+                // Verify added Users were removed on rollback.
+                Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName1"), String.Format("Group '{0}' was not removed on Rollback", "testName1"));
+                Assert.False(UserGroupVerifier.GroupExists(String.Empty, "testName2"), String.Format("Group '{0}' was not removed on Rollback", "testName2"));
+            }
+            finally
+            {
+                // clean up
+                UserGroupVerifier.DeleteLocalGroup("testName1");
+                UserGroupVerifier.DeleteLocalGroup("testName2");
+                UserGroupVerifier.DeleteLocalGroup("testName3");
+            }
         }
 
         #endregion

--- a/src/test/msi/WixToolsetTest.MsiE2E/UtilExtensionUserTests.cs
+++ b/src/test/msi/WixToolsetTest.MsiE2E/UtilExtensionUserTests.cs
@@ -15,66 +15,75 @@ namespace WixToolsetTest.MsiE2E
         [RuntimeFact]
         public void CanInstallAndUninstallUsers()
         {
-            UserVerifier.CreateLocalUser("testName3", "test123!@#");
-            var productA = this.CreatePackageInstaller("ProductA");
+            try
+            {
+                UserVerifier.CreateLocalUser("testName3", "test123!@#");
+                var productA = this.CreatePackageInstaller("ProductA");
 
-            productA.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Validate New User Information.
-            UserVerifier.VerifyUserInformation(String.Empty, "testName1", true, false, false);
-            UserVerifier.VerifyUserIsMemberOf(String.Empty, "testName1", "Administrators", "Power Users");
+                // Validate New User Information.
+                UserVerifier.VerifyUserInformation(String.Empty, "testName1", true, false, false);
+                UserVerifier.VerifyUserIsMemberOf(String.Empty, "testName1", "Administrators", "Power Users");
 
-            UserVerifier.VerifyUserInformation(String.Empty, "testName2", true, true, true);
-            UserVerifier.VerifyUserIsMemberOf(String.Empty, "testName2", "Power Users");
+                UserVerifier.VerifyUserInformation(String.Empty, "testName2", true, true, true);
+                UserVerifier.VerifyUserIsMemberOf(String.Empty, "testName2", "Power Users");
 
-            UserVerifier.VerifyUserIsMemberOf("", "testName3", "Power Users");
+                UserVerifier.VerifyUserIsMemberOf("", "testName3", "Power Users");
 
-            productA.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Verify Users marked as RemoveOnUninstall were removed.
-            Assert.False(UserVerifier.UserExists(String.Empty, "testName1"), String.Format("User '{0}' was not removed on Uninstall", "testName1"));
-            Assert.True(UserVerifier.UserExists(String.Empty, "testName2"), String.Format("User '{0}' was removed on Uninstall", "testName2"));
+                // Verify Users marked as RemoveOnUninstall were removed.
+                Assert.False(UserVerifier.UserExists(String.Empty, "testName1"), String.Format("User '{0}' was not removed on Uninstall", "testName1"));
+                Assert.True(UserVerifier.UserExists(String.Empty, "testName2"), String.Format("User '{0}' was removed on Uninstall", "testName2"));
 
-            // Verify that user added to power users group is removed on uninstall.
-            UserVerifier.VerifyUserIsNotMemberOf("", "testName3", "Power Users");
-
-            // clean up
-            UserVerifier.DeleteLocalUser("testName1");
-            UserVerifier.DeleteLocalUser("testName2");
-            UserVerifier.DeleteLocalUser("testName3");
+                // Verify that user added to power users group is removed on uninstall.
+                UserVerifier.VerifyUserIsNotMemberOf("", "testName3", "Power Users");
+            }
+            finally
+            {
+                // clean up
+                UserVerifier.DeleteLocalUser("testName1");
+                UserVerifier.DeleteLocalUser("testName2");
+                UserVerifier.DeleteLocalUser("testName3");
+            }
         }
 
         // Verify the rollback action reverts all Users changes.
         [RuntimeFact]
         public void CanRollbackUsers()
         {
-            UserVerifier.CreateLocalUser("testName3", "test123!@#", "User3 comment");
-            UserVerifier.AddUserToGroup("testName3", "Backup Operators");
-            var productFail = this.CreatePackageInstaller("ProductFail");
+            try
+            {
+                UserVerifier.CreateLocalUser("testName3", "test123!@#", "User3 comment");
+                UserVerifier.AddUserToGroup("testName3", "Backup Operators");
+                var productFail = this.CreatePackageInstaller("ProductFail");
 
-            // make sure the user accounts are deleted before we start
-            UserVerifier.DeleteLocalUser("testName1");
-            UserVerifier.DeleteLocalUser("testName2");
+                // make sure the user accounts are deleted before we start
+                UserVerifier.DeleteLocalUser("testName1");
+                UserVerifier.DeleteLocalUser("testName2");
 
-            productFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE);
+                productFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE);
 
-            // Verify added Users were removed on rollback.
-            Assert.False(UserVerifier.UserExists(String.Empty, "testName1"), String.Format("User '{0}' was not removed on Rollback", "testName1"));
-            Assert.False(UserVerifier.UserExists(String.Empty, "testName2"), String.Format("User '{0}' was not removed on Rollback", "testName2"));
+                // Verify added Users were removed on rollback.
+                Assert.False(UserVerifier.UserExists(String.Empty, "testName1"), String.Format("User '{0}' was not removed on Rollback", "testName1"));
+                Assert.False(UserVerifier.UserExists(String.Empty, "testName2"), String.Format("User '{0}' was not removed on Rollback", "testName2"));
 
-            // Verify that user added to power users group is removed from power users group on rollback.
-            UserVerifier.VerifyUserIsNotMemberOf("", "testName3", "Power Users");
-            // but is not removed from Backup Operators
-            UserVerifier.VerifyUserIsMemberOf(string.Empty, "testName3", "Backup Operators");
-            // and has their original comment set back
-            UserVerifier.VerifyUserComment(string.Empty, "testName3", "User3 comment");
-
-            // clean up
-            UserVerifier.DeleteLocalUser("testName1");
-            UserVerifier.DeleteLocalUser("testName2");
-            UserVerifier.DeleteLocalUser("testName3");
+                // Verify that user added to power users group is removed from power users group on rollback.
+                UserVerifier.VerifyUserIsNotMemberOf("", "testName3", "Power Users");
+                // but is not removed from Backup Operators
+                UserVerifier.VerifyUserIsMemberOf(string.Empty, "testName3", "Backup Operators");
+                // and has their original comment set back
+                UserVerifier.VerifyUserComment(string.Empty, "testName3", "User3 comment");
+            }
+            finally
+            {
+                // clean up
+                UserVerifier.DeleteLocalUser("testName1");
+                UserVerifier.DeleteLocalUser("testName2");
+                UserVerifier.DeleteLocalUser("testName3");
+            }
         }
-
 
         // Verify that command-line parameters are not blocked by repair switches.
         // Original code signalled repair mode by using "-f ", which silently
@@ -82,63 +91,72 @@ namespace WixToolsetTest.MsiE2E
         [RuntimeFact()]
         public void CanRepairUsersWithCommandLineParameters()
         {
-            var arguments = new string[]
+            try
             {
-                "TESTPARAMETER1=testName1",
-            };
-            var productWithCommandLineParameters = this.CreatePackageInstaller("ProductWithCommandLineParameters");
+                var arguments = new string[]
+                {
+                    "TESTPARAMETER1=testName1",
+                };
+                var productWithCommandLineParameters = this.CreatePackageInstaller("ProductWithCommandLineParameters");
 
-            // Make sure that the user doesn't exist when we start the test.
-            UserVerifier.DeleteLocalUser("testName1");
+                // Make sure that the user doesn't exist when we start the test.
+                UserVerifier.DeleteLocalUser("testName1");
 
-            // Install
-            productWithCommandLineParameters.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
+                // Install
+                productWithCommandLineParameters.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
 
-            // Repair
-            productWithCommandLineParameters.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
-
-            // Clean up
-            UserVerifier.DeleteLocalUser("testName1");
+                // Repair
+                productWithCommandLineParameters.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS, arguments);
+            }
+            finally
+            {
+                // Clean up
+                UserVerifier.DeleteLocalUser("testName1");
+            }
         }
-
 
         // Verify that the users specified in the authoring are created as expected on repair.
         [RuntimeFact()]
         public void CanRepairUsers()
         {
-            UserVerifier.CreateLocalUser("testName3", "test123!@#");
-            var productA = this.CreatePackageInstaller("ProductA");
+            try
+            {
+                UserVerifier.CreateLocalUser("testName3", "test123!@#");
+                var productA = this.CreatePackageInstaller("ProductA");
 
-            productA.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Validate New User Information.
-            UserVerifier.DeleteLocalUser("testName1");
-            UserVerifier.SetUserInformation(String.Empty, "testName2", true, false, false);
+                // Validate New User Information.
+                UserVerifier.DeleteLocalUser("testName1");
+                UserVerifier.SetUserInformation(String.Empty, "testName2", true, false, false);
 
-            productA.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.RepairProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Validate New User Information.
-            UserVerifier.VerifyUserInformation(String.Empty, "testName1", true, false, false);
-            UserVerifier.VerifyUserIsMemberOf(String.Empty, "testName1", "Administrators", "Power Users");
+                // Validate New User Information.
+                UserVerifier.VerifyUserInformation(String.Empty, "testName1", true, false, false);
+                UserVerifier.VerifyUserIsMemberOf(String.Empty, "testName1", "Administrators", "Power Users");
 
-            UserVerifier.VerifyUserInformation(String.Empty, "testName2", true, true, true);
-            UserVerifier.VerifyUserIsMemberOf(String.Empty, "testName2", "Power Users");
+                UserVerifier.VerifyUserInformation(String.Empty, "testName2", true, true, true);
+                UserVerifier.VerifyUserIsMemberOf(String.Empty, "testName2", "Power Users");
 
-            UserVerifier.VerifyUserIsMemberOf("", "testName3", "Power Users");
+                UserVerifier.VerifyUserIsMemberOf("", "testName3", "Power Users");
 
-            productA.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productA.UninstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Verify Users marked as RemoveOnUninstall were removed.
-            Assert.False(UserVerifier.UserExists(String.Empty, "testName1"), String.Format("User '{0}' was not removed on Uninstall", "testName1"));
-            Assert.True(UserVerifier.UserExists(String.Empty, "testName2"), String.Format("User '{0}' was removed on Uninstall", "testName2"));
+                // Verify Users marked as RemoveOnUninstall were removed.
+                Assert.False(UserVerifier.UserExists(String.Empty, "testName1"), String.Format("User '{0}' was not removed on Uninstall", "testName1"));
+                Assert.True(UserVerifier.UserExists(String.Empty, "testName2"), String.Format("User '{0}' was removed on Uninstall", "testName2"));
 
-            // Verify that user added to power users group is removed on uninstall.
-            UserVerifier.VerifyUserIsNotMemberOf("", "testName3", "Power Users");
-
-            // clean up
-            UserVerifier.DeleteLocalUser("testName1");
-            UserVerifier.DeleteLocalUser("testName2");
-            UserVerifier.DeleteLocalUser("testName3");
+                // Verify that user added to power users group is removed on uninstall.
+                UserVerifier.VerifyUserIsNotMemberOf("", "testName3", "Power Users");
+            }
+            finally
+            {
+                // clean up
+                UserVerifier.DeleteLocalUser("testName1");
+                UserVerifier.DeleteLocalUser("testName2");
+                UserVerifier.DeleteLocalUser("testName3");
+            }
         }
 
         // Verify that Installation fails if FailIfExists is set.
@@ -191,93 +209,123 @@ namespace WixToolsetTest.MsiE2E
         [RuntimeFact]
         public void CanCreateNewUserWithComment()
         {
-            var productNewUserWithComment = this.CreatePackageInstaller("ProductNewUserWithComment");
+            try
+            {
+                var productNewUserWithComment = this.CreatePackageInstaller("ProductNewUserWithComment");
 
-            productNewUserWithComment.InstallProduct();
-            UserVerifier.VerifyUserComment(String.Empty, "testName1", "testComment1");
-
-            // clean up
-            UserVerifier.DeleteLocalUser("testName1");
+                productNewUserWithComment.InstallProduct();
+                UserVerifier.VerifyUserComment(String.Empty, "testName1", "testComment1");
+            }
+            finally
+            {
+                // clean up
+                UserVerifier.DeleteLocalUser("testName1");
+            }
         }
 
         // Verify that a comment can be added to an existing user
         [RuntimeFact]
         public void CanAddCommentToExistingUser()
         {
-            UserVerifier.CreateLocalUser("testName1", "test123!@#");
-            var productAddCommentToExistingUser = this.CreatePackageInstaller("ProductAddCommentToExistingUser");
+            try
+            {
+                UserVerifier.CreateLocalUser("testName1", "test123!@#");
+                var productAddCommentToExistingUser = this.CreatePackageInstaller("ProductAddCommentToExistingUser");
 
-            productAddCommentToExistingUser.InstallProduct();
+                productAddCommentToExistingUser.InstallProduct();
 
-            UserVerifier.VerifyUserComment(String.Empty, "testName1", "testComment1");
-
-            // clean up
-            UserVerifier.DeleteLocalUser("testName1");
+                UserVerifier.VerifyUserComment(String.Empty, "testName1", "testComment1");
+            }
+            finally
+            {
+                // clean up
+                UserVerifier.DeleteLocalUser("testName1");
+            }
         }
 
         // Verify that a comment can be repaired for a new user
         [RuntimeFact]
         public void CanRepairCommentOfNewUser()
         {
-            var productNewUserWithComment = this.CreatePackageInstaller("ProductNewUserWithComment");
+            try
+            {
+                var productNewUserWithComment = this.CreatePackageInstaller("ProductNewUserWithComment");
 
-            productNewUserWithComment.InstallProduct();
-            UserVerifier.SetUserComment(String.Empty, "testName1", "");
+                productNewUserWithComment.InstallProduct();
+                UserVerifier.SetUserComment(String.Empty, "testName1", "");
 
-            productNewUserWithComment.RepairProduct();
-            UserVerifier.VerifyUserComment(String.Empty, "testName1", "testComment1");
-
-            // clean up
-            UserVerifier.DeleteLocalUser("testName1");
+                productNewUserWithComment.RepairProduct();
+                UserVerifier.VerifyUserComment(String.Empty, "testName1", "testComment1");
+            }
+            finally
+            {
+                // clean up
+                UserVerifier.DeleteLocalUser("testName1");
+            }
         }
 
         // Verify that a comment can be changed for an existing user
         [RuntimeFact]
         public void CanChangeCommentOfExistingUser()
         {
-            UserVerifier.CreateLocalUser("testName1", "test123!@#");
-            UserVerifier.SetUserComment(String.Empty, "testName1", "initialTestComment1");
-            var productNewUserWithComment = this.CreatePackageInstaller("ProductNewUserWithComment");
+            try
+            {
+                UserVerifier.CreateLocalUser("testName1", "test123!@#");
+                UserVerifier.SetUserComment(String.Empty, "testName1", "initialTestComment1");
+                var productNewUserWithComment = this.CreatePackageInstaller("ProductNewUserWithComment");
 
-            productNewUserWithComment.InstallProduct();
-            UserVerifier.VerifyUserComment(String.Empty, "testName1", "testComment1");
-
-            // clean up
-            UserVerifier.DeleteLocalUser("testName1");
+                productNewUserWithComment.InstallProduct();
+                UserVerifier.VerifyUserComment(String.Empty, "testName1", "testComment1");
+            }
+            finally
+            {
+                // clean up
+                UserVerifier.DeleteLocalUser("testName1");
+            }
         }
 
         // Verify that a comment can be rolled back for an existing user
         [RuntimeFact]
         public void CanRollbackCommentOfExistingUser()
         {
-            UserVerifier.CreateLocalUser("testName1", "test123!@#");
-            UserVerifier.SetUserComment(String.Empty, "testName1", "initialTestComment1");
-            var productCommentFail = this.CreatePackageInstaller("ProductCommentFail");
+            try
+            {
+                UserVerifier.CreateLocalUser("testName1", "test123!@#");
+                UserVerifier.SetUserComment(String.Empty, "testName1", "initialTestComment1");
+                var productCommentFail = this.CreatePackageInstaller("ProductCommentFail");
 
-            productCommentFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE);
+                productCommentFail.InstallProduct(MSIExec.MSIExecReturnCode.ERROR_INSTALL_FAILURE);
 
-            // Verify that comment change was rolled back.
-            UserVerifier.VerifyUserComment(String.Empty, "testName1", "initialTestComment1");
-
-            // clean up
-            UserVerifier.DeleteLocalUser("testName1");
+                // Verify that comment change was rolled back.
+                UserVerifier.VerifyUserComment(String.Empty, "testName1", "initialTestComment1");
+            }
+            finally
+            {
+                // clean up
+                UserVerifier.DeleteLocalUser("testName1");
+            }
         }
 
         // Verify that a comment can be deleted for an existing user
         [RuntimeFact]
         public void CanDeleteCommentOfExistingUser()
         {
-            UserVerifier.CreateLocalUser("testName1", "test123!@#");
-            UserVerifier.SetUserComment(String.Empty, "testName1", "testComment1");
-            var productCommentDelete = this.CreatePackageInstaller("ProductCommentDelete");
+            try
+            {
+                UserVerifier.CreateLocalUser("testName1", "test123!@#");
+                UserVerifier.SetUserComment(String.Empty, "testName1", "testComment1");
+                var productCommentDelete = this.CreatePackageInstaller("ProductCommentDelete");
 
-            productCommentDelete.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
+                productCommentDelete.InstallProduct(MSIExec.MSIExecReturnCode.SUCCESS);
 
-            // Verify that comment was removed.
-            UserVerifier.VerifyUserComment(String.Empty, "testName1", "");
-
-            // clean up
-            UserVerifier.DeleteLocalUser("testName1");
+                // Verify that comment was removed.
+                UserVerifier.VerifyUserComment(String.Empty, "testName1", "");
+            }
+            finally
+            {
+                // clean up
+                UserVerifier.DeleteLocalUser("testName1");
+            }
         }
     }
 }


### PR DESCRIPTION
Ensure user and group integration tests always clean up after themselves - fixes wixtoolset/issues#8940