### PR TITLE
Skip `CanChangeCommentOfExistingNonDomainGroup` test due to CI failures

### DIFF
--- a/src/test/msi/WixToolsetTest.MsiE2E/UtilExtensionGroupTests.cs
+++ b/src/test/msi/WixToolsetTest.MsiE2E/UtilExtensionGroupTests.cs
@@ -243,7 +243,7 @@ namespace WixToolsetTest.MsiE2E
         }
 
         // Verify that a comment can be changed for an existing group
-        [RuntimeFact]
+        [RuntimeFact(Skip = "wixtoolset/issues#8941 - This test fails intermittently in CI. Disabling until the root cause is fixed.")]
         public void CanChangeCommentOfExistingNonDomainGroup()
         {
             try


### PR DESCRIPTION
Related to wixtoolset/issues#8941