### PR TITLE
* ForceAbsent means a package can be removed even if it has other dependants

### DIFF
--- a/src/burn/engine/dependency.cpp
+++ b/src/burn/engine/dependency.cpp
@@ -453,6 +453,7 @@ extern "C" HRESULT DependencyPlanPackageBegin(
     else
     {
         hr = S_OK;
+        BOOL fDependenciesWarned = FALSE;
 
         for (DWORD i = 0; i < pPackage->cDependencyProviders; ++i)
         {
@@ -467,7 +468,15 @@ extern "C" HRESULT DependencyPlanPackageBegin(
                 {
                     hr = S_OK;
 
-                    if (!fDependentBlocksUninstall)
+                    if (pPackage->requested == BOOTSTRAPPER_REQUEST_STATE_FORCE_ABSENT)
+                    {
+                        if (!fDependenciesWarned)
+                        {
+                            fDependenciesWarned = TRUE;
+                            LogId(REPORT_STANDARD, MSG_DEPENDENCY_PACKAGE_DEPENDENTS_OVERRIDDEN, pPackage->sczId);
+                        }
+                    }
+                    else if (!fDependentBlocksUninstall)
                     {
                         fDependentBlocksUninstall = TRUE;
 

--- a/src/burn/engine/engine.mc
+++ b/src/burn/engine/engine.mc
@@ -1282,3 +1282,10 @@ Language=English
 Skipping MSI property '%1!ls!' because condition '%2!ls!' evaluates to %3!hs!.
 .
 
+
+MessageId=701
+Severity=Warning
+SymbolicName=MSG_DEPENDENCY_PACKAGE_DEPENDENTS_OVERRIDDEN
+Language=English
+BA requested to uninstall package: %1!ls!, despite dependents:
+.


### PR DESCRIPTION
Fix https://github.com/wixtoolset/issues/issues/8962