### PR TITLE
Fix internal UI bootstrapper application taskbar icon disappear

### DIFF
--- a/src/ext/Bal/stdbas/WixInternalUIBootstrapperApplication.cpp
+++ b/src/ext/Bal/stdbas/WixInternalUIBootstrapperApplication.cpp
@@ -578,7 +578,7 @@ private:
             dwWindowStyle |= WS_VISIBLE;
         }
 
-        m_hWnd = ::CreateWindowExW(WS_EX_TOOLWINDOW, wc.lpszClassName, NULL, dwWindowStyle, 0, 0, 0, 0, HWND_DESKTOP, NULL, m_hModule, this);
+        m_hWnd = ::CreateWindowExW(WS_EX_APPWINDOW, wc.lpszClassName, NULL, dwWindowStyle, 0, 0, 0, 0, HWND_DESKTOP, NULL, m_hModule, this);
         ExitOnNullWithLastError(m_hWnd, hr, "Failed to create internal UI main window.");
 
     LExit:


### PR DESCRIPTION
As https://github.com/wixtoolset/issues/issues/8135 metion, WixInternalUIBootstrapperApplication cannot show icon on taskbar correctly. Due to the usage of CreateWindowExW in WixToolset.BootstrapperApplications CreateMainWindow, WS_EX_TOOLWINDOW will make the icon disappear in taskbar refer to [document](https://learn.microsoft.com/en-us/windows/win32/winmsg/extended-window-styles). I consider that it is the reason why it cannot show properly.

Fixes https://github.com/wixtoolset/issues/issues/8135