### PR TITLE
Set keypath when parsing naked File child elements

### DIFF
--- a/src/wix/WixToolset.Core/Compiler.cs
+++ b/src/wix/WixToolset.Core/Compiler.cs
@@ -5694,7 +5694,7 @@ namespace WixToolset.Core
                 // so and create a file and component symbol with the right data.
                 id = id ?? this.Core.CreateIdentifier("nkf", directoryId, name, condition, win64.ToString());
 
-                var keyPath = this.ParseFileElementOtherAttributes(node, id.Id, directoryId, diskId: CompilerConstants.IntegerNotSet, id, name, shortName, source, out var _, componentGuid: "*", isNakedFile: true, fileSymbol: out var fileSymbol, assemblySymbol: out var assemblySymbol);
+                this.ParseFileElementOtherAttributes(node, id.Id, directoryId, diskId: CompilerConstants.IntegerNotSet, id, name, shortName, source, out var _, componentGuid: "*", isNakedFile: true, fileSymbol: out var fileSymbol, assemblySymbol: out var assemblySymbol);
 
                 this.Core.AddSymbol(fileSymbol);
 
@@ -5721,7 +5721,7 @@ namespace WixToolset.Core
                     this.Core.AddSymbol(assemblySymbol);
                 }
 
-                this.ParseFileElementChildren(node, fileSymbol, keyPath, win64);
+                this.ParseFileElementChildren(node, fileSymbol, keyPath: YesNoType.Yes, win64);
 
                 // if this is a module, automatically add this component to the references to ensure it gets in the ModuleComponents table
                 if (this.compilingModule)

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/DirectoryRef.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/DirectoryRef.wxs
@@ -2,16 +2,11 @@
   <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
     <MajorUpgrade DowngradeErrorMessage="Downgrade error message." />
 
+    <!-- Relies on default INSTALLFOLDER feature. -->
     <DirectoryRef Id="INSTALLFOLDER">
       <!-- Relies on default-feature feature to include naked files in package. -->
       <File Id="test.txt" Source="test.txt" />
       <File Id="test2.txt" Source="test.txt" Name="test2.txt" />
     </DirectoryRef>
   </Package>
-  
-  <Fragment>
-    <StandardDirectory Id="ProgramFilesFolder">
-      <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
-    </StandardDirectory>
-  </Fragment>
 </Wix>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Package.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/NakedFile/Package.wxs
@@ -1,6 +1,8 @@
 <Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
     <Package Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation" UpgradeCode="047730a5-30fe-4a62-a520-da9381b8226a">
-        <File Directory="INSTALLFOLDER" Subdirectory="X" Source="test.txt" />
+        <File Directory="INSTALLFOLDER" Subdirectory="X" Source="test.txt">
+            <Shortcut Advertise="yes" Directory="ProgramMenuFolder" Name="Test" />
+        </File>
         <File Directory="INSTALLFOLDER" Subdirectory="X" Source="test.txt" Name="test2.txt" />
         <File Directory="INSTALLFOLDER" Subdirectory="X3" Source="test.txt" Name="test3.txt" />
         <File Directory="INSTALLFOLDER" Subdirectory="X4" Source="test.txt" Name="test4.txt" />


### PR DESCRIPTION
Fixes https://github.com/wixtoolset/issues/issues/8976