### PR TITLE
Add missing `CustomTableSetting` parameter in `ConvertCommand`

### DIFF
--- a/src/wix/WixToolset.Converters/ConvertCommand.cs
+++ b/src/wix/WixToolset.Converters/ConvertCommand.cs
@@ -36,7 +36,7 @@ namespace WixToolset.Converters
         {
             this.ParseSettings(SettingsFileDefault);
 
-            var converter = new WixConverter(this.Messaging, this.IndentationAmount, this.ErrorsAsWarnings, this.IgnoreErrors);
+            var converter = new WixConverter(this.Messaging, this.IndentationAmount, this.ErrorsAsWarnings, this.IgnoreErrors, this.CustomTableSetting);
 
             var errors = base.Inspect(Inspector, cancellationToken);
 


### PR DESCRIPTION
Passes the missing `customTableTarget` argument to the ConvertCommand instance.

Fixes wixtoolset/issues#8972