### PR TITLE
Harvesting no longer aborts if any exclusions reference missing folders

### DIFF
--- a/src/wix/test/WixToolsetTest.CoreIntegration/HarvestFilesFixture.cs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/HarvestFilesFixture.cs
@@ -57,6 +57,30 @@ namespace WixToolsetTest.CoreIntegration
         }
 
         [Fact]
+        public void MissingHarvestExclusionsDoesNotBlockAllHarvesting()
+        {
+            Build("SomeExclusionsMissing.wxs", (msiPath, sourceFolder, baseFolder, result) =>
+            {
+                var expectedWarnings = new[]
+                {
+                    @"8601: Missing directory for harvesting files: Could not find a part of the path '<sourceFolder>\files2\files2_sub2\MissingDirectory'.",
+                    @"8601: Missing directory for harvesting files: Could not find a part of the path '<sourceFolder>\files2\files2_sub2\ThisDirectoryIsAlsoMissing'.",
+                };
+
+                var expectedFiles = new[]
+                {
+                    @"flsCswDB8sBfZz7_oHNtra3tiFivPE=PFiles\MsiPackage\test20.txt",
+                    @"fls4200C_IADZMINQyhQg52G3WxxfU=PFiles\MsiPackage\test21.txt",
+                };
+
+                var messages = result.Messages.Select(m => FormatMessage(m, sourceFolder, baseFolder)).ToArray();
+                WixAssert.CompareLineByLine(expectedWarnings, messages);
+
+                AssertFileIdsAndTargetPaths(msiPath, expectedFiles);
+            }, warningsAsErrors: false);
+        }
+
+        [Fact]
         public void DuplicateFilesSomethingSomething()
         {
             Build("DuplicateFiles.wxs", (_, result) =>

--- a/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/SomeExclusionsMissing.wxs
+++ b/src/wix/test/WixToolsetTest.CoreIntegration/TestData/HarvestFiles/SomeExclusionsMissing.wxs
@@ -1,0 +1,17 @@
+<Wix xmlns="http://wixtoolset.org/schemas/v4/wxs">
+    <Package Id="WixToolsetTest.SomeExclusionsMissing" Name="MsiPackage" Version="1.0.0.0" Manufacturer="Example Corporation">
+
+        <Files Include="files2\files2_sub2\**">
+            <Exclude Files="files2\files2_sub2\MissingDirectory\**" />
+            <Exclude Files="files2\files2_sub2\pleasedontincludeme.dat" />
+            <Exclude Files="files2\files2_sub2\ThisDirectoryIsAlsoMissing\**" />
+        </Files>
+
+    </Package>
+
+    <Fragment>
+        <StandardDirectory Id="ProgramFilesFolder">
+            <Directory Id="INSTALLFOLDER" Name="MsiPackage" />
+        </StandardDirectory>
+    </Fragment>
+</Wix>


### PR DESCRIPTION
Fixes wixtoolset/issues#8989
