### PR TITLE
Switch to MSTest built-in Test target.

### DIFF
--- a/src/Directory.csproj.targets
+++ b/src/Directory.csproj.targets
@@ -20,16 +20,6 @@
     <TestingPlatformShowTestsFailure>true</TestingPlatformShowTestsFailure>
   </PropertyGroup>
 
-  <Target Name="RunWixTests" AfterTargets="Build" Condition=" '$(IsWixMSTestProject)' == 'true' AND '$(SuppressWixTests)' != 'true' ">
-    <Delete Files="$(TestResultsFolder)$(MSBuildProjectName).trx" />
-
-    <Exec 
-      Command="$(TargetPath.Replace('.dll', '.exe')) --results-directory $(TestResultsFolder) --report-trx --report-trx-filename $(MSBuildProjectName).trx --no-progress --settings $([MSBuild]::GetPathOfFileAbove('wix.runsettings'))" 
-      UseCommandProcessor="false" 
-      CustomErrorRegularExpression="  Test method .+ threw exception:" />
-  </Target>   
-
-
   <ItemGroup Condition=" '$(IsWixTestProject)'=='true' ">
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit" />

--- a/src/ext/Bal/bal_t.proj
+++ b/src/ext/Bal/bal_t.proj
@@ -18,6 +18,8 @@
 
     <ProjectReference Include="test\examples\examples.proj" />
 
+    <ProjectReference Include="test\WixToolsetTest.BootstrapperApplications\WixToolsetTest.BootstrapperApplications.csproj" Targets="Test" />
+
     <!-- 
     Currently there are no unskipped unit tests in this project. Should that change,
     we'll need to update the native test framework or figure out something else.

--- a/src/ext/ComPlus/complus_t.proj
+++ b/src/ext/ComPlus/complus_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.ComPlus\WixToolsetTest.ComPlus.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.ComPlus\WixToolsetTest.ComPlus.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.ComPlus.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/Dependency/dependency_t.proj
+++ b/src/ext/Dependency/dependency_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.Dependency\WixToolsetTest.Dependency.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.Dependency\WixToolsetTest.Dependency.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.Dependency.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/DirectX/directx_t.proj
+++ b/src/ext/DirectX/directx_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.DirectX\WixToolsetTest.DirectX.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.DirectX\WixToolsetTest.DirectX.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.DirectX.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/Firewall/firewall_t.proj
+++ b/src/ext/Firewall/firewall_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.Firewall\WixToolsetTest.Firewall.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.Firewall\WixToolsetTest.Firewall.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.Firewall.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/Http/http_t.proj
+++ b/src/ext/Http/http_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.Http\WixToolsetTest.Http.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.Http\WixToolsetTest.Http.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.Http.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/Iis/iis_t.proj
+++ b/src/ext/Iis/iis_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.Iis\WixToolsetTest.Iis.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.Iis\WixToolsetTest.Iis.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.Iis.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/Msmq/msmq_t.proj
+++ b/src/ext/Msmq/msmq_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.Msmq\WixToolsetTest.Msmq.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.Msmq\WixToolsetTest.Msmq.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.Msmq.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/NetFx/netfx_t.proj
+++ b/src/ext/NetFx/netfx_t.proj
@@ -4,7 +4,7 @@
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
     <ProjectReference Include="wixlib\netfx.wixproj" />
-    <ProjectReference Include="test\WixToolsetTest.Netfx\WixToolsetTest.Netfx.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.Netfx\WixToolsetTest.Netfx.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.Netfx.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/PowerShell/powershell_t.proj
+++ b/src/ext/PowerShell/powershell_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.PowerShell\WixToolsetTest.Powershell.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.PowerShell\WixToolsetTest.Powershell.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.PowerShell.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/Sql/sql_t.proj
+++ b/src/ext/Sql/sql_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.Sql\WixToolsetTest.Sql.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.Sql\WixToolsetTest.Sql.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.Sql.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/UI/ui_t.proj
+++ b/src/ext/UI/ui_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.UI\WixToolsetTest.UI.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.UI\WixToolsetTest.UI.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.UI.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/Util/util_t.proj
+++ b/src/ext/Util/util_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.Util\WixToolsetTest.Util.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.Util\WixToolsetTest.Util.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.Util.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/VisualStudio/visualstudio_t.proj
+++ b/src/ext/VisualStudio/visualstudio_t.proj
@@ -3,7 +3,7 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <ProjectReference Include="test\WixToolsetTest.VisualStudio\WixToolsetTest.VisualStudio.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.VisualStudio\WixToolsetTest.VisualStudio.csproj" Targets="Test" />
     <ProjectReference Include="wixext\WixToolset.VisualStudio.wixext.csproj" Targets="Pack" Properties="NoBuild=true" />
   </ItemGroup>
 

--- a/src/ext/ext_t.proj
+++ b/src/ext/ext_t.proj
@@ -3,15 +3,9 @@
 
 <Project Sdk="Microsoft.Build.Traversal">
   <ItemGroup>
-    <!-- These projects are "special." -->
-    <ProjectReference Include="Util\util_t.proj" BuildInParallel="false" Targets="Restore;Build" Properties="SuppressWixTests=true" />
-    <ProjectReference Include="Bal\bal_t.proj" BuildInParallel="false" Targets="Restore;Build" Properties="SuppressWixTests=true" />
-    <!-- <ProjectReference Include="NetFx\netfx_t.proj" BuildInParallel="false" Targets="Restore;Build" Properties="SuppressWixTests=true" /> -->
-
-    <!-- Now run tests we skipped earlier along with everything in parallel. -->
-    <ProjectReference Include="Util\util_t.proj" Targets="Build" />
-    <ProjectReference Include="Bal\bal_t.proj" Targets="Build" />
-    <!-- <ProjectReference Include="NetFx\netfx_t.proj" Targets="Build" /> -->
+    <!-- These projects are "special" and cannot build in parallel. -->
+    <ProjectReference Include="Util\util_t.proj" BuildInParallel="false" Targets="Restore;Build" />
+    <ProjectReference Include="Bal\bal_t.proj" BuildInParallel="false" Targets="Restore;Build" />
 
     <ProjectReference Include="NetFx\netfx_t.proj" BuildInParallel="false" Targets="Restore;Build" />
     <ProjectReference Include="ComPlus\complus_t.proj" Targets="Restore;Build" />

--- a/src/internal/SetBuildNumber/Directory.Packages.props.pp
+++ b/src/internal/SetBuildNumber/Directory.Packages.props.pp
@@ -100,7 +100,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageVersion Include="MSTest.TestFramework" Version="3.8.0" />
+    <PackageVersion Include="MSTest.TestFramework" Version="3.8.3" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/internal/SetBuildNumber/global.json.pp
+++ b/src/internal/SetBuildNumber/global.json.pp
@@ -1,6 +1,6 @@
 {
   "msbuild-sdks": {
-    "MSTest.Sdk": "3.8.0",
+    "MSTest.Sdk": "3.8.3",
     "Microsoft.Build.Traversal": "4.1.82",
     "Microsoft.Build.NoTargets": "3.5.6",
     "WixToolset.Sdk": "{packageversion}"

--- a/src/tools/tools_t.proj
+++ b/src/tools/tools_t.proj
@@ -12,8 +12,8 @@
     <!-- <ProjectReference Include="heat\heat.csproj" />
     <ProjectReference Include="WixToolset.HeatTasks\WixToolset.HeatTasks.csproj" /> -->
 
-    <ProjectReference Include="test\WixToolsetTest.HeatTasks\WixToolsetTest.HeatTasks.csproj" />
-    <ProjectReference Include="test\WixToolsetTest.Heat\WixToolsetTest.Heat.csproj" />
+    <ProjectReference Include="test\WixToolsetTest.HeatTasks\WixToolsetTest.HeatTasks.csproj" Targets="Test" />
+    <ProjectReference Include="test\WixToolsetTest.Heat\WixToolsetTest.Heat.csproj" Targets="Test" />
 
     <ProjectReference Include="WixToolset.Heat\WixToolset.Heat.csproj" Targets="Pack" />
   </ItemGroup>

--- a/src/wix/wix.cmd
+++ b/src/wix/wix.cmd
@@ -26,7 +26,7 @@ msbuild -t:Restore wix.sln -p:Configuration=%_C% -tl -nologo -m -warnaserror -bl
 :: Build
 msbuild wixnative\wixnative_t.proj -p:Configuration=%_C% -tl -nologo -m -warnaserror -bl:%_L%\wixnative_build.binlog || exit /b
 
-msbuild wix.sln -p:Configuration=%_C% -p:SuppressWixTests=true -tl -nologo -m -warnaserror -bl:%_L%\wix_build.binlog || exit /b
+msbuild wix.sln -p:Configuration=%_C% -tl -nologo -m -warnaserror -bl:%_L%\wix_build.binlog || exit /b
 
 msbuild publish_t.proj -p:Configuration=%_C% -tl -nologo -warnaserror -bl:%_L%\wix_publish.binlog || exit /b
 
@@ -35,7 +35,7 @@ msbuild -t:Publish -p:Configuration=%_C% -tl -nologo -warnaserror WixToolset.Sdk
 :: TODO - used by MsbuildFixture.ReportsInnerExceptionForUnexpectedExceptions test
 :: msbuild -t:Publish -Restore -p:Configuration=%_C% -p:TargetFramework=net472 -p:RuntimeIdentifier=linux-x86 -p:PublishDir=%_P%WixToolset.Sdk\broken\net472\ wix\wix.csproj || exit /b
 
-msbuild -t:RunWixTests test\WixToolsetTest.Sdk\WixToolsetTest.Sdk.csproj -p:Configuration=%_C% -p:NoBuild=true -tl -nologo -warnaserror  || exit /b
+msbuild -t:Test test\WixToolsetTest.Sdk\WixToolsetTest.Sdk.csproj -p:Configuration=%_C% -tl -nologo -warnaserror  || exit /b
 
 :: Test
 dotnet test ^


### PR DESCRIPTION
Prevents test run during VS build and shows failure details on console (no need to dig into TRX file).