### PR TITLE
Support launching rundll32.exe as a safe executable if the dll it loads is in a secure location

### DIFF
--- a/src/burn/engine/approvedexe.h
+++ b/src/burn/engine/approvedexe.h
@@ -58,7 +58,9 @@ HRESULT ApprovedExesLaunch(
 HRESULT ApprovedExesVerifySecureLocation(
     __in BURN_CACHE* pCache,
     __in BURN_VARIABLES* pVariables,
-    __in LPCWSTR wzExecutablePath
+    __in LPCWSTR wzExecutablePath,
+    __in int argc,
+    __in LPCWSTR* argv
     );
 
 

--- a/src/burn/engine/bundlepackageengine.cpp
+++ b/src/burn/engine/bundlepackageengine.cpp
@@ -817,7 +817,7 @@ static HRESULT ExecuteBundle(
 
         if (pPackage->fPerMachine)
         {
-            hr = ApprovedExesVerifySecureLocation(pCache, pVariables, sczExecutablePath);
+            hr = ApprovedExesVerifySecureLocation(pCache, pVariables, sczExecutablePath, argcArp - 1, (argcArp > 1) ? const_cast<LPCWSTR*>(argvArp + 1) : NULL);
             ExitOnFailure(hr, "Failed to verify the QuietUninstallString executable path is in a secure location: %ls", sczExecutablePath);
             if (S_FALSE == hr)
             {

--- a/src/burn/engine/elevation.cpp
+++ b/src/burn/engine/elevation.cpp
@@ -3876,7 +3876,7 @@ static HRESULT OnLaunchApprovedExe(
     hr = RegReadString(hKey, pApprovedExe->sczValueName, &pLaunchApprovedExe->sczExecutablePath);
     ExitOnFailure(hr, "Failed to read the value for the approved exe path.");
 
-    hr = ApprovedExesVerifySecureLocation(pCache, pVariables, pLaunchApprovedExe->sczExecutablePath);
+    hr = ApprovedExesVerifySecureLocation(pCache, pVariables, pLaunchApprovedExe->sczExecutablePath, 0, NULL);
     ExitOnFailure(hr, "Failed to verify the executable path is in a secure location: %ls", pLaunchApprovedExe->sczExecutablePath);
     if (S_FALSE == hr)
     {

--- a/src/burn/test/BurnUnitTest/ApprovedExeTest.cpp
+++ b/src/burn/test/BurnUnitTest/ApprovedExeTest.cpp
@@ -1,0 +1,312 @@
+// Copyright (c) .NET Foundation and contributors. All rights reserved. Licensed under the Microsoft Reciprocal License. See LICENSE.TXT file in the project root for full license information.
+
+#include "precomp.h"
+
+namespace Microsoft
+{
+namespace Tools
+{
+namespace WindowsInstallerXml
+{
+namespace Test
+{
+namespace Bootstrapper
+{
+    using namespace System;
+    using namespace System::IO;
+    using namespace Xunit;
+
+    public ref class ApprovedExeTest : BurnUnitTest
+    {
+    public:
+        ApprovedExeTest(BurnTestFixture^ fixture) : BurnUnitTest(fixture)
+        {
+        }
+
+        [Fact]
+        void ApprovedExesVerifyPFilesTest()
+        {
+            HRESULT hr = S_OK;
+            BURN_CACHE cache = { };
+            BURN_ENGINE_COMMAND internalCommand = { };
+            BURN_VARIABLES variables = { };
+            LPWSTR scz = NULL;
+            LPWSTR scz2 = NULL;
+
+            try
+            {
+                hr = VariableInitialize(&variables);
+                NativeAssert::Succeeded(hr, L"Failed to initialize variables.");
+
+                hr = CacheInitialize(&cache, &internalCommand);
+                NativeAssert::Succeeded(hr, "Failed to initialize cache.");
+
+                hr = VariableGetString(&variables, L"ProgramFilesFolder", &scz);
+                NativeAssert::Succeeded(hr, "Failed to get variable ProgramFilesFolder.");
+
+                hr = PathConcat(scz, L"a.exe", &scz2);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = ApprovedExesVerifySecureLocation(&cache, &variables, scz2, 0, NULL);
+                NativeAssert::Succeeded(hr, "Failed to test secure location under ProgramFilesFolder");
+                Assert::True((hr == S_OK), "Path under ProgramFilesFolder was expected to be safe");
+            }
+            finally
+            {
+                ReleaseStr(internalCommand.sczEngineWorkingDirectory);
+                ReleaseStr(scz);
+                ReleaseStr(scz2);
+
+                CacheUninitialize(&cache);
+                VariablesUninitialize(&variables);
+            }
+        }
+
+        [Fact]
+        void ApprovedExesVerifyPFilesWithRelativeTest()
+        {
+            HRESULT hr = S_OK;
+            BURN_CACHE cache = { };
+            BURN_ENGINE_COMMAND internalCommand = { };
+            BURN_VARIABLES variables = { };
+            LPWSTR scz = NULL;
+            LPWSTR scz2 = NULL;
+
+            try
+            {
+                hr = VariableInitialize(&variables);
+                NativeAssert::Succeeded(hr, L"Failed to initialize variables.");
+
+                hr = CacheInitialize(&cache, &internalCommand);
+                NativeAssert::Succeeded(hr, "Failed to initialize cache.");
+                cache.fPerMachineCacheRootVerified = TRUE;
+                cache.fOriginalPerMachineCacheRootVerified = TRUE;
+
+                hr = VariableGetString(&variables, L"ProgramFilesFolder", &scz);
+                NativeAssert::Succeeded(hr, "Failed to get variable ProgramFilesFolder.");
+
+                hr = PathConcat(scz, L"..\\a.exe", &scz2);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = ApprovedExesVerifySecureLocation(&cache, &variables, scz2, 0, NULL);
+                NativeAssert::Succeeded(hr, "Failed to test secure location under ProgramFilesFolder");
+                Assert::True((hr == S_FALSE), "Path pretending to be under ProgramFilesFolder was expected to be unsafe");
+            }
+            finally
+            {
+                ReleaseStr(internalCommand.sczEngineWorkingDirectory);
+                ReleaseStr(scz);
+                ReleaseStr(scz2);
+
+                CacheUninitialize(&cache);
+                VariablesUninitialize(&variables);
+            }
+        }
+
+        [Fact]
+        void ApprovedExesVerifyPFiles64Test()
+        {
+            HRESULT hr = S_OK;
+            BURN_CACHE cache = { };
+            BURN_ENGINE_COMMAND internalCommand = { };
+            BURN_VARIABLES variables = { };
+            LPWSTR scz = NULL;
+            LPWSTR scz2 = NULL;
+
+            try
+            {
+                hr = VariableInitialize(&variables);
+                NativeAssert::Succeeded(hr, L"Failed to initialize variables.");
+
+                hr = CacheInitialize(&cache, &internalCommand);
+                NativeAssert::Succeeded(hr, "Failed to initialize cache.");
+
+                hr = VariableGetString(&variables, L"ProgramFiles64Folder", &scz);
+                NativeAssert::Succeeded(hr, "Failed to get variable ProgramFiles64Folder.");
+
+                hr = PathConcat(scz, L"a.exe", &scz2);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = ApprovedExesVerifySecureLocation(&cache, &variables, scz2, 0, NULL);
+                NativeAssert::Succeeded(hr, "Failed to test secure location under ProgramFiles64Folder");
+                Assert::True((hr == S_OK), "Path under ProgramFiles64Folder was expected to be safe");
+            }
+            finally
+            {
+                ReleaseStr(internalCommand.sczEngineWorkingDirectory);
+                ReleaseStr(scz);
+                ReleaseStr(scz2);
+
+                CacheUninitialize(&cache);
+                VariablesUninitialize(&variables);
+            }
+        }
+
+        [Fact]
+        void ApprovedExesVerifySys64FolderTest()
+        {
+            HRESULT hr = S_OK;
+            BURN_CACHE cache = { };
+            BURN_ENGINE_COMMAND internalCommand = { };
+            BURN_VARIABLES variables = { };
+            LPWSTR scz = NULL;
+            LPWSTR scz2 = NULL;
+
+            try
+            {
+                hr = VariableInitialize(&variables);
+                NativeAssert::Succeeded(hr, L"Failed to initialize variables.");
+
+                hr = CacheInitialize(&cache, &internalCommand);
+                NativeAssert::Succeeded(hr, "Failed to initialize cache.");
+                cache.fPerMachineCacheRootVerified = TRUE;
+                cache.fOriginalPerMachineCacheRootVerified = TRUE;
+
+                hr = VariableGetString(&variables, L"System64Folder", &scz);
+                NativeAssert::Succeeded(hr, "Failed to get variable System64Folder.");
+
+                hr = PathConcat(scz, L"a.exe", &scz2);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = ApprovedExesVerifySecureLocation(&cache, &variables, scz2, 0, NULL);
+                NativeAssert::Succeeded(hr, "Failed to test secure location under System64Folder");
+                Assert::True((hr == S_FALSE), "Path under System64Folder was expected to be unsafe");
+            }
+            finally
+            {
+                ReleaseStr(internalCommand.sczEngineWorkingDirectory);
+                ReleaseStr(scz);
+                ReleaseStr(scz2);
+
+                CacheUninitialize(&cache);
+                VariablesUninitialize(&variables);
+            }
+        }
+
+        [Fact]
+        void ApprovedExesVerifySys64Rundll32UnsafeTest()
+        {
+            HRESULT hr = S_OK;
+            BURN_CACHE cache = { };
+            BURN_ENGINE_COMMAND internalCommand = { };
+            BURN_VARIABLES variables = { };
+            LPWSTR scz = NULL;
+            LPWSTR scz2 = NULL;
+            LPWSTR szArgs = NULL;
+
+            try
+            {
+                hr = VariableInitialize(&variables);
+                NativeAssert::Succeeded(hr, L"Failed to initialize variables.");
+
+                hr = CacheInitialize(&cache, &internalCommand);
+                NativeAssert::Succeeded(hr, "Failed to initialize cache.");
+                cache.fPerMachineCacheRootVerified = TRUE;
+                cache.fOriginalPerMachineCacheRootVerified = TRUE;
+
+                hr = VariableGetString(&variables, L"System64Folder", &scz);
+                NativeAssert::Succeeded(hr, "Failed to get variable System64Folder.");
+
+                hr = PathConcat(scz, L"rundll32.exe", &scz2);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = ApprovedExesVerifySecureLocation(&cache, &variables, scz2, 1, const_cast<LPCWSTR*>(&scz2));
+                NativeAssert::Succeeded(hr, "Failed to test secure location under System64Folder");
+                Assert::True((hr == S_FALSE), "Path under System64Folder was expected to be unsafe for rundll32 target");
+            }
+            finally
+            {
+                ReleaseStr(internalCommand.sczEngineWorkingDirectory);
+                ReleaseStr(scz);
+                ReleaseStr(scz2);
+                ReleaseStr(szArgs);
+
+                CacheUninitialize(&cache);
+                VariablesUninitialize(&variables);
+            }
+        }
+
+        [Fact]
+        void ApprovedExesVerifySys64Rundll32SafeTest()
+        {
+            HRESULT hr = S_OK;
+            BURN_CACHE cache = { };
+            BURN_ENGINE_COMMAND internalCommand = { };
+            BURN_VARIABLES variables = { };
+            LPWSTR scz = NULL;
+            LPWSTR scz2 = NULL;
+            LPWSTR scz3 = NULL;
+
+            try
+            {
+                hr = VariableInitialize(&variables);
+                NativeAssert::Succeeded(hr, L"Failed to initialize variables.");
+
+                hr = CacheInitialize(&cache, &internalCommand);
+                NativeAssert::Succeeded(hr, "Failed to initialize cache.");
+                cache.fPerMachineCacheRootVerified = TRUE;
+                cache.fOriginalPerMachineCacheRootVerified = TRUE;
+
+                // System64Folder
+                hr = VariableGetString(&variables, L"System64Folder", &scz);
+                NativeAssert::Succeeded(hr, "Failed to get variable System64Folder.");
+
+                hr = PathConcat(scz, L"rundll32.exe", &scz2);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = VariableGetString(&variables, L"ProgramFiles64Folder", &scz);
+                NativeAssert::Succeeded(hr, "Failed to get variable ProgramFiles64Folder.");
+
+                hr = PathConcat(scz, L"a.dll", &scz3);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = ApprovedExesVerifySecureLocation(&cache, &variables, scz2, 1, const_cast<LPCWSTR*>(&scz3));
+                NativeAssert::Succeeded(hr, "Failed to test secure location under ProgramFiles64Folder for System64Folder/rundll32 target");
+                Assert::True((hr == S_OK), "Path under ProgramFiles64Folder was expected to be safe for System64Folder/rundll32 target");
+
+                hr = PathConcat(scz, L"a.dll,somthing else", &scz3);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = ApprovedExesVerifySecureLocation(&cache, &variables, scz2, 1, const_cast<LPCWSTR*>(&scz3));
+                NativeAssert::Succeeded(hr, "Failed to test secure location under ProgramFiles64Folder for rundll32 target");
+                Assert::True((hr == S_OK), "Path under ProgramFiles64Folder was expected to be safe for System64Folder/rundll32 target");
+
+                // SystemFolder
+                hr = VariableGetString(&variables, L"SystemFolder", &scz);
+                NativeAssert::Succeeded(hr, "Failed to get variable System64Folder.");
+
+                hr = PathConcat(scz, L"rundll32.exe", &scz2);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = ApprovedExesVerifySecureLocation(&cache, &variables, scz2, 1, const_cast<LPCWSTR*>(&scz3));
+                NativeAssert::Succeeded(hr, "Failed to test secure location under ProgramFiles64Folder for SystemFolder/rundll32 target");
+                Assert::True((hr == S_OK), "Path under ProgramFiles64Folder was expected to be safe for SystemFolder/rundll32 target");
+
+                // Sysnative
+                hr = PathSystemWindowsSubdirectory(L"SysNative\\", &scz);
+                NativeAssert::Succeeded(hr, "Failed to get SysNative Folder.");
+
+                hr = PathConcat(scz, L"rundll32.exe", &scz2);
+                NativeAssert::Succeeded(hr, "Failed to combine paths");
+
+                hr = ApprovedExesVerifySecureLocation(&cache, &variables, scz2, 1, const_cast<LPCWSTR*>(&scz3));
+                NativeAssert::Succeeded(hr, "Failed to test secure location under ProgramFiles64Folder for Sysnative/rundll32 target");
+                Assert::True((hr == S_OK), "Path under ProgramFiles64Folder was expected to be safe for Sysnative/rundll32 target");
+            }
+            finally
+            {
+                ReleaseStr(internalCommand.sczEngineWorkingDirectory);
+                ReleaseStr(scz);
+                ReleaseStr(scz2);
+                ReleaseStr(scz3);
+
+                CacheUninitialize(&cache);
+                VariablesUninitialize(&variables);
+            }
+        }
+    };
+}
+}
+}
+}
+}

--- a/src/burn/test/BurnUnitTest/BurnUnitTest.vcxproj
+++ b/src/burn/test/BurnUnitTest/BurnUnitTest.vcxproj
@@ -45,6 +45,7 @@
 
   <ItemGroup>
     <ClCompile Include="AssemblyInfo.cpp" />
+    <ClCompile Include="ApprovedExeTest.cpp" />
     <ClCompile Include="CacheTest.cpp" />
     <ClCompile Include="ElevationTest.cpp" />
     <ClCompile Include="EmbeddedTest.cpp" />

--- a/src/burn/test/BurnUnitTest/BurnUnitTest.vcxproj.filters
+++ b/src/burn/test/BurnUnitTest/BurnUnitTest.vcxproj.filters
@@ -66,6 +66,9 @@
     <ClCompile Include="VariantTest.cpp">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="ApprovedExeTest.cpp">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="BurnTestException.h">

--- a/src/burn/test/BurnUnitTest/precomp.h
+++ b/src/burn/test/BurnUnitTest/precomp.h
@@ -74,6 +74,7 @@
 #include "splashscreen.h"
 #include "detect.h"
 #include "externalengine.h"
+#include "approvedexe.h"
 
 #include "engine.version.h"
 

--- a/src/test/burn/WixToolsetTest.BurnE2E/ExePackageTests.cs
+++ b/src/test/burn/WixToolsetTest.BurnE2E/ExePackageTests.cs
@@ -30,7 +30,7 @@ namespace WixToolsetTest.BurnE2E
             perMachineArpEntryExePackageBundle.VerifyUnregisteredAndRemovedFromPackageCache();
             arpEntryExePackage.VerifyRegistered(false);
 
-            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}"));
+            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}\""));
         }
 
         [RuntimeFact]
@@ -52,7 +52,7 @@ namespace WixToolsetTest.BurnE2E
             perMachineArpEntryExePackageBundle.VerifyUnregisteredAndRemovedFromPackageCache();
             arpEntryExePackage.VerifyRegistered(false);
 
-            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}"));
+            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}\""));
         }
 
         [RuntimeFact]
@@ -85,7 +85,7 @@ namespace WixToolsetTest.BurnE2E
             packageTestExe.VerifyInstalled(true);
 
             Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, "TESTBA: OnCachePackageNonVitalValidationFailure() - id: TestExe, default: None, requested: Acquire"));
-            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}"));
+            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}\""));
             Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"TestExe.exe\" /regw \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId},DisplayVersion,String,1.0.0.0\" /regw \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId},QuietUninstallString,String,\\\""));
         }
 
@@ -113,7 +113,7 @@ namespace WixToolsetTest.BurnE2E
             packageTestExe.VerifyInstalled(true);
 
             Assert.False(LogVerifier.MessageInLogFile(uninstallLogPath, "TESTBA: OnCachePackageNonVitalValidationFailure() - id: TestExe"));
-            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}"));
+            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}\""));
             Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"TestExe.exe\" /regw \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId},DisplayVersion,String,1.0.0.0\" /regw \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId},QuietUninstallString,String,\\\""));
         }
 
@@ -144,7 +144,7 @@ namespace WixToolsetTest.BurnE2E
             packageTestExe.VerifyInstalled(true);
 
             Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, "TESTBA: OnCachePackageNonVitalValidationFailure() - id: TestExe, default: None, requested: None"));
-            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}"));
+            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}\""));
         }
 
         [RuntimeFact]
@@ -161,7 +161,7 @@ namespace WixToolsetTest.BurnE2E
             arpEntryExePackage.VerifyRegistered(false);
 
             Assert.True(LogVerifier.MessageInLogFile(installLogPath, $"TestExe.exe\" /regw \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId},DisplayVersion,String,1.0.0.0\" /regw \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId},QuietUninstallString,String,\\\""));
-            Assert.True(LogVerifier.MessageInLogFile(installLogPath, $"testexe.exe\" /regd HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}"));
+            Assert.True(LogVerifier.MessageInLogFile(installLogPath, $"testexe.exe\" /regd \"HKLM\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}\""));
         }
 
         [RuntimeFact]
@@ -209,7 +209,7 @@ namespace WixToolsetTest.BurnE2E
             perUserArpEntryExePackageBundle.VerifyUnregisteredAndRemovedFromPackageCache();
             arpEntryExePackage.VerifyRegistered(false);
 
-            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}"));
+            Assert.True(LogVerifier.MessageInLogFile(uninstallLogPath, $"testexe.exe\" /regd \"HKCU\\SOFTWARE\\Microsoft\\Windows\\CurrentVersion\\Uninstall\\{arpId}\""));
         }
 
         [RuntimeFact]


### PR DESCRIPTION
Closes https://github.com/wixtoolset/issues/issues/9025