### PR TITLE
Always pass `-quiet` to related bundles.

### DIFF
--- a/src/burn/engine/bundlepackageengine.cpp
+++ b/src/burn/engine/bundlepackageengine.cpp
@@ -940,7 +940,7 @@ static HRESULT ExecuteBundle(
 
     if (wzRelationTypeCommandLine)
     {
-        hr = StrAllocConcatFormatted(&sczBaseCommand, L" -%ls", wzRelationTypeCommandLine);
+        hr = StrAllocConcatFormatted(&sczBaseCommand, L" -quiet -%ls", wzRelationTypeCommandLine);
         ExitOnFailure(hr, "Failed to append relation type argument.");
     }
 


### PR DESCRIPTION
The embedding protocol implies no-UI but if Burn doesn't detect a compatible protocol, it won't use the embedding switch. This provides a backup to keep it silent.

Fixes https://github.com/wixtoolset/issues/issues/7969