### PR TITLE
Update ErrorMessages.cs to refine duplicate identifiers message

### DIFF
--- a/src/api/wix/WixToolset.Data/ErrorMessages.cs
+++ b/src/api/wix/WixToolset.Data/ErrorMessages.cs
@@ -295,7 +295,7 @@ namespace WixToolset.Data
 
         public static Message DuplicateLocalizationIdentifier(SourceLineNumber sourceLineNumbers, string localizationId)
         {
-            return Message(sourceLineNumbers, Ids.DuplicateLocalizationIdentifier, "The localization identifier '{0}' has been duplicated in multiple locations. Please resolve the conflict.", localizationId);
+            return Message(sourceLineNumbers, Ids.DuplicateLocalizationIdentifier, "Either the localization identifier '{0}' has been duplicated in multiple locations or you are missing a default culture file. Please resolve the conflict.", localizationId);
         }
 
         public static Message DuplicateModuleCaseInsensitiveFileIdentifier(SourceLineNumber sourceLineNumbers, string moduleId, string fileId1, string fileId2)

--- a/src/api/wix/WixToolset.Data/ErrorMessages.cs
+++ b/src/api/wix/WixToolset.Data/ErrorMessages.cs
@@ -295,7 +295,7 @@ namespace WixToolset.Data
 
         public static Message DuplicateLocalizationIdentifier(SourceLineNumber sourceLineNumbers, string localizationId)
         {
-            return Message(sourceLineNumbers, Ids.DuplicateLocalizationIdentifier, "Either the localization identifier '{0}' has been duplicated in multiple locations or you are missing a default culture file. Please resolve the conflict.", localizationId);
+            return Message(sourceLineNumbers, Ids.DuplicateLocalizationIdentifier, "The localization identifier '{0}' has been duplicated in multiple locations. A common cause is a bundle .wixproj that automatically loads .wxl files that are intended for the bootstrapper application. You can turn off that behavior by setting the EnableDefaultEmbeddedResourceItems property to false.", localizationId);
         }
 
         public static Message DuplicateModuleCaseInsensitiveFileIdentifier(SourceLineNumber sourceLineNumbers, string moduleId, string fileId1, string fileId2)


### PR DESCRIPTION
Adds information about necessary neutral language definition.

If multiple language files are defined in burn, but no neutral language is given, this error message is returned. But without the proposed change it is not clear why this error appears.

See [Discussion 9081](https://github.com/orgs/wixtoolset/discussions/9081), too.