### PR TITLE
Fix for issue9118 - wrong elevation detection for non-admin accounts with UAC disabled

### DIFF
--- a/src/libs/dutil/WixToolset.DUtil/procutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/procutil.cpp
@@ -44,6 +44,14 @@ extern "C" HRESULT DAPI ProcElevated(
     HANDLE hToken = NULL;
     TOKEN_ELEVATION tokenElevated = { };
     DWORD cbToken = 0;
+    BOOL bPrivileged = FALSE;
+
+    if (OsCouldRunPrivileged(&bPrivileged) != S_OK ||
+        !bPrivileged)
+    {
+        *pfElevated = FALSE;
+        ExitFunction1(hr = S_OK);
+    }
 
     if (!::OpenProcessToken(hProcess, TOKEN_QUERY, &hToken))
     {


### PR DESCRIPTION
Fix for issue: https://github.com/wixtoolset/issues/issues/9118
When user is not in admin group and UAC is disabled, wix may wrongly detect process as elevated