### PR TITLE
Fix for issue 9104 - Relation patch bundle check should not be done during uninstall

### DIFF
--- a/src/burn/engine/plan.cpp
+++ b/src/burn/engine/plan.cpp
@@ -376,20 +376,6 @@ extern "C" HRESULT PlanDefaultPackageRequestState(
             break;
         }
     }
-    else if (BOOTSTRAPPER_RELATION_PATCH == relationType && BURN_PACKAGE_TYPE_MSP == packageType)
-    {
-        // For patch related bundles, only install a patch if currently absent during install, modify, or repair.
-        if (BOOTSTRAPPER_PACKAGE_STATE_ABSENT != currentState)
-        {
-            *pRequestState = BOOTSTRAPPER_REQUEST_STATE_NONE;
-        }
-        else if (BOOTSTRAPPER_ACTION_INSTALL == action ||
-                 BOOTSTRAPPER_ACTION_MODIFY == action ||
-                 BOOTSTRAPPER_ACTION_REPAIR == action)
-        {
-            *pRequestState = BOOTSTRAPPER_REQUEST_STATE_PRESENT;
-        }
-    }
     else // pick the best option for the action state and install condition.
     {
         hr = GetActionDefaultRequestState(action, currentState, &defaultRequestState);
@@ -397,9 +383,23 @@ extern "C" HRESULT PlanDefaultPackageRequestState(
 
         if (BOOTSTRAPPER_ACTION_UNINSTALL != action && BOOTSTRAPPER_ACTION_UNSAFE_UNINSTALL != action)
         {
+            if (BOOTSTRAPPER_RELATION_PATCH == relationType && BURN_PACKAGE_TYPE_MSP == packageType)
+            {
+                // For patch related bundles, only install a patch if currently absent during install, modify, or repair.
+                if (BOOTSTRAPPER_PACKAGE_STATE_ABSENT != currentState)
+                {
+                    defaultRequestState = BOOTSTRAPPER_REQUEST_STATE_NONE;
+                }
+                else if (BOOTSTRAPPER_ACTION_INSTALL == action ||
+                         BOOTSTRAPPER_ACTION_MODIFY == action ||
+                         BOOTSTRAPPER_ACTION_REPAIR == action)
+                {
+                    defaultRequestState = BOOTSTRAPPER_REQUEST_STATE_PRESENT;
+                }
+            }
             // If we're not doing an uninstall, use the install condition
             // to determine whether to use the default request state or make the package absent.
-            if (BOOTSTRAPPER_PACKAGE_CONDITION_FALSE == installCondition)
+            else if (BOOTSTRAPPER_PACKAGE_CONDITION_FALSE == installCondition)
             {
                 defaultRequestState = BOOTSTRAPPER_REQUEST_STATE_ABSENT;
             }


### PR DESCRIPTION
Fix for issue: https://github.com/wixtoolset/issues/issues/9104

This PR fixes the issue when the parent bundle is uninstalled, all related bundle is not uninstalled and orphaned. The request state is incorrect because it did not check for uninstall action.