### PR TITLE
Skip SetConsoleCP when stdout is non-interactive

### DIFF
--- a/src/libs/dutil/WixToolset.DUtil/conutil.cpp
+++ b/src/libs/dutil/WixToolset.DUtil/conutil.cpp
@@ -67,9 +67,14 @@ extern "C" HRESULT DAPI ConsoleInitialize()
         vfConsoleOut = TRUE;
     }
 
-    if (!::SetConsoleCP(CP_UTF8) || !::SetConsoleOutputCP(CP_UTF8))
+    // Console codepage only applies to interactive sessions. SetConsoleCP may
+    // fail in console-less environments and the error path closes stdin/stdout.
+    if (vfStdOutInteractive)
     {
-        ConExitWithLastError(hr, "failed to set console codepage to UTF-8");
+        if (!::SetConsoleCP(CP_UTF8) || !::SetConsoleOutputCP(CP_UTF8))
+        {
+            ConExitWithLastError(hr, "failed to set console codepage to UTF-8");
+        }
     }
 
 LExit:


### PR DESCRIPTION
When stdout is a pipe (e.g. wixnative.exe spawned by wix.exe), SetConsoleCP/SetConsoleOutputCP may fail if the console subsystem has not been initialized. The failure path in ConsoleInitialize closes the stdin/stdout pipe handles, causing wixnative to exit and wix.exe to get IOException: The pipe is being closed.

This gates the SetConsoleCP calls on vfStdOutInteractive, which is already computed earlier in ConsoleInitialize. Pipe-based I/O does not use the console codepage — both sides handle UTF-8 encoding explicitly.

Fixes wixtoolset/issues#9267