### PR TITLE
Also find MSBuild v18 (vs 2026) when running tests

### DIFF
--- a/src/internal/WixInternal.MSTestSupport/MsbuildRunner.cs
+++ b/src/internal/WixInternal.MSTestSupport/MsbuildRunner.cs
@@ -8,7 +8,7 @@ namespace WixInternal.MSTestSupport
 
     public class MsbuildRunner : ExternalExecutable
     {
-        private static readonly string VswhereFindArguments = "-property installationPath -version [17.0,18.0)";
+        private static readonly string VswhereFindArguments = "-property installationPath -version [17.0,19.0)";
         private static readonly string MsbuildCurrentRelativePath = @"MSBuild\Current\Bin\MSBuild.exe";
         private static readonly string MsbuildCurrentRelativePath64 = @"MSBuild\Current\Bin\amd64\MSBuild.exe";
 

--- a/src/internal/WixInternal.TestSupport/MsbuildRunner.cs
+++ b/src/internal/WixInternal.TestSupport/MsbuildRunner.cs
@@ -8,7 +8,7 @@ namespace WixInternal.TestSupport
 
     public class MsbuildRunner : ExternalExecutable
     {
-        private static readonly string VswhereFindArguments = "-property installationPath -version [17.0,18.0)";
+        private static readonly string VswhereFindArguments = "-property installationPath -version [17.0,19.0)";
         private static readonly string MsbuildCurrentRelativePath = @"MSBuild\Current\Bin\MSBuild.exe";
         private static readonly string MsbuildCurrentRelativePath64 = @"MSBuild\Current\Bin\amd64\MSBuild.exe";
 


### PR DESCRIPTION
VswhereFindArguments in MsBuildrunner.cs only includes versions up to 17, excluding 18 (VS 2026). This PR changes that to include 18, too

fixes wixtoolset/issues#9269