### PR TITLE
Fix build on machines with only VS2026

### DIFF
--- a/src/internal/WixInternal.MSTestSupport/MsbuildRunner.cs
+++ b/src/internal/WixInternal.MSTestSupport/MsbuildRunner.cs
@@ -8,7 +8,7 @@ namespace WixInternal.MSTestSupport
 
     public class MsbuildRunner : ExternalExecutable
     {
-        private static readonly string VswhereFindArguments = "-property installationPath -version [17.0,18.0)";
+        private static readonly string VswhereFindArguments = "-property installationPath -version [18.0,19.0)";
         private static readonly string MsbuildCurrentRelativePath = @"MSBuild\Current\Bin\MSBuild.exe";
         private static readonly string MsbuildCurrentRelativePath64 = @"MSBuild\Current\Bin\amd64\MSBuild.exe";
 

--- a/src/internal/WixInternal.TestSupport/MsbuildRunner.cs
+++ b/src/internal/WixInternal.TestSupport/MsbuildRunner.cs
@@ -8,7 +8,7 @@ namespace WixInternal.TestSupport
 
     public class MsbuildRunner : ExternalExecutable
     {
-        private static readonly string VswhereFindArguments = "-property installationPath -version [17.0,18.0)";
+        private static readonly string VswhereFindArguments = "-property installationPath -version [18.0,19.0)";
         private static readonly string MsbuildCurrentRelativePath = @"MSBuild\Current\Bin\MSBuild.exe";
         private static readonly string MsbuildCurrentRelativePath64 = @"MSBuild\Current\Bin\amd64\MSBuild.exe";
 


### PR DESCRIPTION
I couldn't build WiX on a machine with VS2026 (with 2022 toolset), because test runner searches for VS2022.
